### PR TITLE
Adding CRON with supervisord

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -13,7 +13,7 @@ RUN docker-php-ext-install imap intl mbstring mcrypt mysqli pdo pdo_mysql
 VOLUME /var/www/html
 
 # Define Mautic version and expected SHA1 signature
-ENV MAUTIC_VERSION 1.2.4
+ENV MAUTIC_VERSION 1.3.0
 ENV MAUTIC_SHA1 f0f89343f9ce67b6b4cafb44fd7b15f325ed726f
 
 # Download package and extract to web volume

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -29,5 +29,12 @@ COPY docker-entrypoint.sh /entrypoint.sh
 COPY makeconfig.php /makeconfig.php
 COPY makedb.php /makedb.php
 
+# Install Supervisor and Cron
+RUN apt-get update && apt-get install -y supervisor cron
+RUN mkdir -p /var/log/supervisor
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY crontabFile /crontabFile
+RUN /usr/bin/crontab /crontabFile
+
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["apache2-foreground"]
+CMD ["/usr/bin/supervisord"]

--- a/apache/crontabFile
+++ b/apache/crontabFile
@@ -1,0 +1,37 @@
+# Edit this file to introduce tasks to be run by cron.
+# 
+# Each task to run has to be defined through a single line
+# indicating with different fields when the task will be run
+# and what command to run for the task
+# 
+# To define the time you can provide concrete values for
+# minute (m), hour (h), day of month (dom), month (mon),
+# and day of week (dow) or use '*' in these fields (for 'any').# 
+# Notice that tasks will be started based on the cron's system
+# daemon's notion of time and timezones.
+# 
+# Output of the crontab jobs (including errors) is sent through
+# email to the user the crontab file belongs to (unless redirected).
+# 
+# For example, you can run a backup of all your user accounts
+# at 5 a.m every week with:
+# 0 5 * * 1 tar -zcf /var/backups/home.tgz /home/
+# 
+# For more information see the manual pages of crontab(5) and cron(8)
+# 
+# m h  dom mon dow   command
+# Every two minutes
+# 1-59/2 * * * *
+# Every five minutes
+# */5 * * * *
+# Every 30 minutes
+# */30 * * * *
+
+1-59/2 * * * * php  /var/www/html/app/console mautic:leadlists:update  >/dev/null 2>&1
+1-59/2 * * * * php /var/www/html/app/console mautic:campaigns:update  >/dev/null 2>&1
+1-59/2 * * * * php /var/www/html/app/console mautic:campaigns:trigger  >/dev/null 2>&1
+1-59/2 * * * * php /var/www/html/app/console mautic:email:process  >/dev/null 2>&1
+*/30 * * * * php /var/www/html/app/console mautic:fetch:email >/dev/null 2>&1
+1-59/2 * * * * php /var/www/html/app/console mautic:webhooks:process >/dev/null 2>&1
+# Once a week
+0 6 * * 1 php /var/www/html/app/console mautic:iplookup:download >/dev/null 2>&1

--- a/apache/crontabFile
+++ b/apache/crontabFile
@@ -27,11 +27,11 @@
 # Every 30 minutes
 # */30 * * * *
 
-* * * * * /usr/local/bin/php  /var/www/html/app/console mautic:leadlists:update
+* * * * * /usr/local/bin/php /var/www/html/app/console mautic:leadlists:update
 * * * * * /usr/local/bin/php /var/www/html/app/console mautic:campaigns:update
 * * * * * /usr/local/bin/php /var/www/html/app/console mautic:campaigns:trigger
-* * * * * /usr/local/bin/php /var/www/html/app/console mautic:email:process 
-* * * * * php /var/www/html/app/console mautic:fetch:email 
-* * * * * php /var/www/html/app/console mautic:webhooks:process 
+*/5 * * * * /usr/local/bin/php /var/www/html/app/console mautic:email:process 
+*/30 * * * * /usr/local/bin/php /var/www/html/app/console mautic:fetch:email 
+* * * * * /usr/local/bin/php /var/www/html/app/console mautic:webhooks:process 
 # Once a week
 0 6 * * 1 php /var/www/html/app/console mautic:iplookup:download >/dev/null 2>&1

--- a/apache/crontabFile
+++ b/apache/crontabFile
@@ -27,11 +27,11 @@
 # Every 30 minutes
 # */30 * * * *
 
-1-59/2 * * * * php  /var/www/html/app/console mautic:leadlists:update  >/dev/null 2>&1
-1-59/2 * * * * php /var/www/html/app/console mautic:campaigns:update  >/dev/null 2>&1
-1-59/2 * * * * php /var/www/html/app/console mautic:campaigns:trigger  >/dev/null 2>&1
-1-59/2 * * * * php /var/www/html/app/console mautic:email:process  >/dev/null 2>&1
-*/30 * * * * php /var/www/html/app/console mautic:fetch:email >/dev/null 2>&1
-1-59/2 * * * * php /var/www/html/app/console mautic:webhooks:process >/dev/null 2>&1
+* * * * * /usr/local/bin/php  /var/www/html/app/console mautic:leadlists:update
+* * * * * /usr/local/bin/php /var/www/html/app/console mautic:campaigns:update
+* * * * * /usr/local/bin/php /var/www/html/app/console mautic:campaigns:trigger
+* * * * * /usr/local/bin/php /var/www/html/app/console mautic:email:process 
+* * * * * php /var/www/html/app/console mautic:fetch:email 
+* * * * * php /var/www/html/app/console mautic:webhooks:process 
 # Once a week
 0 6 * * 1 php /var/www/html/app/console mautic:iplookup:download >/dev/null 2>&1

--- a/apache/supervisord.conf
+++ b/apache/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:cron]
-command	= cron -f
+command = /bin/bash -c "service cron start && crontab /crontabFile"
 stdout_logfile = /var/log/supervisor/%(program_name)s.log
 stderr_logfile = /var/log/supervisor/%(program_name)s.log
 autorestart = true

--- a/apache/supervisord.conf
+++ b/apache/supervisord.conf
@@ -1,0 +1,14 @@
+[supervisord]
+nodaemon=true
+
+[program:cron]
+command	= cron -f
+stdout_logfile = /var/log/supervisor/%(program_name)s.log
+stderr_logfile = /var/log/supervisor/%(program_name)s.log
+autorestart = true
+
+[program:apache2]
+command=/bin/bash -c "source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND"
+stdout_logfile	= /var/log/supervisor/%(program_name)s.log
+stderr_logfile	= /var/log/supervisor/%(program_name)s.log
+autorestart	= true


### PR DESCRIPTION
I made a version only for the apache container. Did not add any change to the main and fpm containers.
I added supervisord, and did not try to add Env variables to further configure the cron jobs. This could be added in a future version
