### PR TITLE
Updated to support mautic 2.0.0.

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -8,13 +8,13 @@ RUN a2enmod rewrite
 RUN apt-get update && apt-get install -y libc-client-dev libicu-dev libkrb5-dev libmcrypt-dev libssl-dev unzip zip
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure imap --with-imap --with-imap-ssl --with-kerberos
-RUN docker-php-ext-install imap intl mbstring mcrypt mysqli pdo pdo_mysql
+RUN docker-php-ext-install imap intl mbstring mcrypt mysqli pdo pdo_mysql zip
 
 VOLUME /var/www/html
 
 # Define Mautic version and expected SHA1 signature
-ENV MAUTIC_VERSION 1.2.4
-ENV MAUTIC_SHA1 f0f89343f9ce67b6b4cafb44fd7b15f325ed726f
+ENV MAUTIC_VERSION 2.0.0
+ENV MAUTIC_SHA1 42197c6ddc7e4a505e6785e1bc794b212c4d6fb1
 
 # Download package and extract to web volume
 RUN curl -o mautic.zip -SL https://s3.amazonaws.com/mautic/releases/${MAUTIC_VERSION}.zip \
@@ -28,6 +28,8 @@ RUN curl -o mautic.zip -SL https://s3.amazonaws.com/mautic/releases/${MAUTIC_VER
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makeconfig.php /makeconfig.php
 COPY makedb.php /makedb.php
+RUN cp /usr/src/php/php.ini-production /usr/local/etc/php/php.ini \
+    && sed -i -e "/always_populate_raw_post_data/ s/^;//" /usr/local/etc/php/php.ini
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -28,8 +28,12 @@ RUN curl -o mautic.zip -SL https://s3.amazonaws.com/mautic/releases/${MAUTIC_VER
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makeconfig.php /makeconfig.php
 COPY makedb.php /makedb.php
-RUN cp /usr/src/php/php.ini-production /usr/local/etc/php/php.ini \
-    && sed -i -e "/always_populate_raw_post_data/ s/^;//" /usr/local/etc/php/php.ini
+RUN tar xf /usr/src/php.tar.xz \
+        -C /usr/local/etc/php/ \
+        --strip-components 1 \
+        php-5.6.23/php.ini-production \
+  && mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini \
+  && sed -i -e "/always_populate_raw_post_data/ s/^;//" /usr/local/etc/php/php.ini
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -67,6 +67,8 @@ if ! [ -e app/config/local.php ]; then
 
         # Make sure our web user owns the config file if it exists
         chown www-data:www-data app/config/local.php
+        mkdir  /var/www/html/app/logs
+        chown www-data:www-data  /var/www/html/app/logs
 fi
 
 exec "$@"

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -5,13 +5,13 @@ MAINTAINER Michael Babker <michael.babker@mautic.org> (@mbabker)
 RUN apt-get update && apt-get install -y libc-client-dev libicu-dev libkrb5-dev libmcrypt-dev libssl-dev unzip zip
 RUN rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure imap --with-imap --with-imap-ssl --with-kerberos
-RUN docker-php-ext-install imap intl mbstring mcrypt mysqli pdo pdo_mysql
+RUN docker-php-ext-install fcgi imap intl mbstring mcrypt mysqli pdo pdo_mysql zip
 
 VOLUME /var/www/html
 
 # Define Mautic version and expected SHA1 signature
-ENV MAUTIC_VERSION 1.2.4
-ENV MAUTIC_SHA1 f0f89343f9ce67b6b4cafb44fd7b15f325ed726f
+ENV MAUTIC_VERSION 2.0.0
+ENV MAUTIC_SHA1 42197c6ddc7e4a505e6785e1bc794b212c4d6fb1
 
 # Download package and extract to web volume
 RUN curl -o mautic.zip -SL https://s3.amazonaws.com/mautic/releases/${MAUTIC_VERSION}.zip \
@@ -25,6 +25,8 @@ RUN curl -o mautic.zip -SL https://s3.amazonaws.com/mautic/releases/${MAUTIC_VER
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makeconfig.php /makeconfig.php
 COPY makedb.php /makedb.php
+RUN cp /usr/src/php/php.ini-production /usr/local/etc/php/php.ini \
+    && sed -i -e "/always_populate_raw_post_data/ s/^;//" /usr/local/etc/php/php.ini
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -25,8 +25,11 @@ RUN curl -o mautic.zip -SL https://s3.amazonaws.com/mautic/releases/${MAUTIC_VER
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY makeconfig.php /makeconfig.php
 COPY makedb.php /makedb.php
-RUN cp /usr/src/php/php.ini-production /usr/local/etc/php/php.ini \
-    && sed -i -e "/always_populate_raw_post_data/ s/^;//" /usr/local/etc/php/php.ini
-
+RUN tar xf /usr/src/php.tar.xz \
+        -C /usr/local/etc/php/ \
+        --strip-components 1 \
+        php-5.6.23/php.ini-production \
+  && mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini \
+  && sed -i -e "/always_populate_raw_post_data/ s/^;//" /usr/local/etc/php/php.ini
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -67,6 +67,8 @@ if ! [ -e app/config/local.php ]; then
 
         # Make sure our web user owns the config file if it exists
         chown www-data:www-data app/config/local.php
+        mkdir  /var/www/html/app/logs
+        chown www-data:www-data  /var/www/html/app/logs
 fi
 
 exec "$@"


### PR DESCRIPTION
Hi,

This PR updates the Dockerfiles to support the latest version of mautic 2.x, tested with docker 1.11.2.

https://www.mautic.org/latest.json still returns 1.2.4, I suppose is because the containers still haven't been updated ?

About the fpm image, I haven't used fpm before so I'm not sure how it is designed to be used. It requires an external web server like apache or nginx, or is the Dockerfile unfinished ?
