### PR TITLE
Fix ZLIB error in docker-ext-install zip

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libkrb5-dev \
     libmcrypt-dev \
     libssl-dev \
+    libz-dev \
     unzip \
     zip \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libkrb5-dev \
     libmcrypt-dev \
     libssl-dev \
+    libz-dev \
     unzip \
     zip \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \


### PR DESCRIPTION
Added the libz-dev dependencie to fix zlib error when try to run "docker-php-ext-install zip".