### PR TITLE
Add mysql version for the docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can access and customize Docker Mautic from [Official Docker Hub image](http
 
 # Running Basic Container
 
-	docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw mysql &
+	docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw mysql:5.7 &
 	docker run --name some-mautic --link some-mysql:mysql mautic/mautic
 
 ## Customizing Mautic Container


### PR DESCRIPTION
Out of the box, the current version of mautic docker is not compatible with version 8.x of mysql
This PR simply add a reference to the version 5.7