### PR TITLE
install bcmath php extension

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 RUN docker-php-ext-configure imap --with-imap --with-imap-ssl --with-kerberos \
     && docker-php-ext-configure opcache --enable-opcache \
-    && docker-php-ext-install imap intl mbstring mcrypt mysqli pdo_mysql zip opcache \
-    && docker-php-ext-enable imap intl mbstring mcrypt mysqli pdo_mysql zip opcache
+    && docker-php-ext-install imap intl mbstring mcrypt mysqli pdo_mysql zip opcache bcmath\
+    && docker-php-ext-enable imap intl mbstring mcrypt mysqli pdo_mysql zip opcache bcmath
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer


### PR DESCRIPTION
fixes error:
`Uncaught PHP Exception Symfony\Component\Debug\Exception\UndefinedFunctionException: "Attempted to call function "bcadd" from namespace "PhpAmqpLib\Wire"." at /var/www/html/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/AMQPWriter.php line 274 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\UndefinedFunctionException(code: 0): Attempted to call function \"bcadd\" from namespace \"PhpAmqpLib\\Wire\". at /var/www/html/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/AMQPWriter.php:274)"} []`
which calls **bcadd** function from bcmath extension