### PR TITLE
Add PHP.ini setup to fix #78 & fix #69

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ If the `MAUTIC_DB_NAME` specified does not already exist on the given MySQL serv
 ### Enable / Disable Features
 -   `-e MAUTIC_TESTER=...` (defaults to empty) Enables Mautic Github Pull Tester  [documentation](https://github.com/mautic/mautic-tester)
 
+### PHP options
+-	`-e PHP_INI_DATE_TIMEZONE=...` (defaults to `UTC`) Set PHP timezone
+-	`-e PHP_MEMORY_LIMIT=...` (defaults to `256M`) Set PHP memory limit
+-	`-e PHP_MAX_UPLOAD=...` (defaults to `20M`) Set PHP upload max file size
+-	`-e PHP_MAX_EXECUTION_TIME=...` (defaults to `300`) Set PHP max execution time
+
 
 ### Persistent Data Volumes
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -45,8 +45,8 @@ ENV MAUTIC_DB_NAME mautic
 
 # Setting PHP properties
 ENV PHP_INI_DATE_TIMEZONE='UTC' \
-	PHP_MEMORY_LIMIT=256M \
-	PHP_MAX_UPLOAD=20M \
+	PHP_MEMORY_LIMIT=512M \
+	PHP_MAX_UPLOAD=128M \
 	PHP_MAX_EXECUTION_TIME=300
 
 # Download package and extract to web volume
@@ -63,7 +63,6 @@ COPY makeconfig.php /makeconfig.php
 COPY makedb.php /makedb.php
 COPY mautic.crontab /etc/cron.d/mautic
 RUN chmod 644 /etc/cron.d/mautic
-COPY mautic-php.ini /usr/local/etc/php/conf.d/mautic-php.ini
 
 # Enable Apache Rewrite Module
 RUN a2enmod rewrite

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -43,6 +43,12 @@ ENV MAUTIC_RUN_CRON_JOBS true
 ENV MAUTIC_DB_USER root
 ENV MAUTIC_DB_NAME mautic
 
+# Setting PHP properties
+ENV PHP_INI_DATE_TIMEZONE='UTC' \
+	PHP_MEMORY_LIMIT=256M \
+	PHP_MAX_UPLOAD=20M \
+	PHP_MAX_EXECUTION_TIME=300
+
 # Download package and extract to web volume
 RUN curl -o mautic.zip -SL https://github.com/mautic/mautic/releases/download/${MAUTIC_VERSION}/${MAUTIC_VERSION}.zip \
 	&& echo "$MAUTIC_SHA1 *mautic.zip" | sha1sum -c - \

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -4,8 +4,11 @@ set -e
 if [ ! -f /usr/local/etc/php/php.ini ]; then
 	cat <<EOF > /usr/local/etc/php/php.ini
 date.timezone = "${PHP_INI_DATE_TIMEZONE}"
+always_populate_raw_post_data = -1
 memory_limit = ${PHP_MEMORY_LIMIT}
+file_uploads = On
 upload_max_filesize = ${PHP_MAX_UPLOAD}
+post_max_size = ${PHP_MAX_UPLOAD}
 max_execution_time = ${PHP_MAX_EXECUTION_TIME}
 EOF
 fi

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+if [ ! -f /usr/local/etc/php/php.ini ]; then
+	cat <<EOF > /usr/local/etc/php/php.ini
+date.timezone = "${PHP_INI_DATE_TIMEZONE}"
+memory_limit = ${PHP_MEMORY_LIMIT}
+upload_max_filesize = ${PHP_MAX_UPLOAD}
+max_execution_time = ${PHP_MAX_EXECUTION_TIME}
+EOF
+fi
+
+
 if [ -n "$MYSQL_PORT_3306_TCP" ]; then
         if [ -z "$MAUTIC_DB_HOST" ]; then
                 export MAUTIC_DB_HOST='mysql'

--- a/apache/makeconfig.php
+++ b/apache/makeconfig.php
@@ -36,6 +36,10 @@ if(array_key_exists('MAUTIC_TRUSTED_PROXIES', $_ENV)) {
     $parameters['trusted_proxies'] = $proxies;
 }
 
+if(array_key_exists('PHP_INI_DATE_TIMEZONE', $_ENV)) {
+    $parameters['default_timezone'] = $_ENV['PHP_INI_DATE_TIMEZONE'];
+}
+
 $path     = '/var/www/html/app/config/local.php';
 $rendered = "<?php\n\$parameters = ".var_export($parameters, true).";\n";
 

--- a/apache/mautic-php.ini
+++ b/apache/mautic-php.ini
@@ -1,5 +1,0 @@
-always_populate_raw_post_data = -1
-memory_limit = 512M
-file_uploads = On
-upload_max_filesize=128M
-post_max_size=128M

--- a/beta-apache/Dockerfile
+++ b/beta-apache/Dockerfile
@@ -42,6 +42,12 @@ ENV MAUTIC_RUN_CRON_JOBS true
 ENV MAUTIC_DB_USER root
 ENV MAUTIC_DB_NAME mautic
 
+# Setting PHP properties
+ENV PHP_INI_DATE_TIMEZONE='UTC' \
+	PHP_MEMORY_LIMIT=256M \
+	PHP_MAX_UPLOAD=20M \
+	PHP_MAX_EXECUTION_TIME=300
+
 # Download package and extract to web volume
 RUN curl -o mautic.zip -SL https://github.com/mautic/mautic/releases/download/${MAUTIC_VERSION}/${MAUTIC_VERSION}.zip \
 	&& echo "$MAUTIC_SHA1 *mautic.zip" | sha1sum -c - \

--- a/beta-apache/Dockerfile
+++ b/beta-apache/Dockerfile
@@ -44,8 +44,8 @@ ENV MAUTIC_DB_NAME mautic
 
 # Setting PHP properties
 ENV PHP_INI_DATE_TIMEZONE='UTC' \
-	PHP_MEMORY_LIMIT=256M \
-	PHP_MAX_UPLOAD=20M \
+	PHP_MEMORY_LIMIT=512M \
+	PHP_MAX_UPLOAD=128M \
 	PHP_MAX_EXECUTION_TIME=300
 
 # Download package and extract to web volume
@@ -62,7 +62,6 @@ COPY makeconfig.php /makeconfig.php
 COPY makedb.php /makedb.php
 COPY mautic.crontab /etc/cron.d/mautic
 RUN chmod 644 /etc/cron.d/mautic
-COPY mautic-php.ini /usr/local/etc/php/conf.d/mautic-php.ini
 
 # Enable Apache Rewrite Module
 RUN a2enmod rewrite

--- a/beta-apache/docker-entrypoint.sh
+++ b/beta-apache/docker-entrypoint.sh
@@ -4,8 +4,11 @@ set -e
 if [ ! -f /usr/local/etc/php/php.ini ]; then
 	cat <<EOF > /usr/local/etc/php/php.ini
 date.timezone = "${PHP_INI_DATE_TIMEZONE}"
+always_populate_raw_post_data = -1
 memory_limit = ${PHP_MEMORY_LIMIT}
+file_uploads = On
 upload_max_filesize = ${PHP_MAX_UPLOAD}
+post_max_size = ${PHP_MAX_UPLOAD}
 max_execution_time = ${PHP_MAX_EXECUTION_TIME}
 EOF
 fi

--- a/beta-apache/docker-entrypoint.sh
+++ b/beta-apache/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+if [ ! -f /usr/local/etc/php/php.ini ]; then
+	cat <<EOF > /usr/local/etc/php/php.ini
+date.timezone = "${PHP_INI_DATE_TIMEZONE}"
+memory_limit = ${PHP_MEMORY_LIMIT}
+upload_max_filesize = ${PHP_MAX_UPLOAD}
+max_execution_time = ${PHP_MAX_EXECUTION_TIME}
+EOF
+fi
+
+
 if [ -n "$MYSQL_PORT_3306_TCP" ]; then
         if [ -z "$MAUTIC_DB_HOST" ]; then
                 export MAUTIC_DB_HOST='mysql'
@@ -122,7 +132,6 @@ fi
 
 echo >&2
 echo >&2 "========================================================================"
-
 
 
 # Github Pull Tester

--- a/beta-apache/makeconfig.php
+++ b/beta-apache/makeconfig.php
@@ -33,6 +33,10 @@ if(array_key_exists('MAUTIC_TRUSTED_PROXIES', $_ENV)) {
     $parameters['trusted_proxies'] = $proxies;
 }
 
+if(array_key_exists('PHP_INI_DATE_TIMEZONE', $_ENV)) {
+    $parameters['default_timezone'] = $_ENV['PHP_INI_DATE_TIMEZONE'];
+}
+
 $path     = '/var/www/html/app/config/local.php';
 $rendered = "<?php\n\$parameters = ".var_export($parameters, true).";\n";
 

--- a/beta-apache/mautic-php.ini
+++ b/beta-apache/mautic-php.ini
@@ -1,5 +1,0 @@
-always_populate_raw_post_data = -1
-memory_limit = 512M
-file_uploads = On
-upload_max_filesize=128M
-post_max_size=128M

--- a/beta-fpm/Dockerfile
+++ b/beta-fpm/Dockerfile
@@ -44,8 +44,8 @@ ENV MAUTIC_DB_NAME mautic
 
 # Setting PHP properties
 ENV PHP_INI_DATE_TIMEZONE='UTC' \
-	PHP_MEMORY_LIMIT=256M \
-	PHP_MAX_UPLOAD=20M \
+	PHP_MEMORY_LIMIT=512M \
+	PHP_MAX_UPLOAD=128M \
 	PHP_MAX_EXECUTION_TIME=300
 
 # Download package and extract to web volume
@@ -62,7 +62,6 @@ COPY makeconfig.php /makeconfig.php
 COPY makedb.php /makedb.php
 COPY mautic.crontab /etc/cron.d/mautic
 RUN chmod 644 /etc/cron.d/mautic
-COPY mautic-php.ini /usr/local/etc/php/conf.d/mautic-php.ini
 
 # Apply necessary permissions
 RUN ["chmod", "+x", "/entrypoint.sh"]

--- a/beta-fpm/Dockerfile
+++ b/beta-fpm/Dockerfile
@@ -42,6 +42,12 @@ ENV MAUTIC_RUN_CRON_JOBS true
 ENV MAUTIC_DB_USER root
 ENV MAUTIC_DB_NAME mautic
 
+# Setting PHP properties
+ENV PHP_INI_DATE_TIMEZONE='UTC' \
+	PHP_MEMORY_LIMIT=256M \
+	PHP_MAX_UPLOAD=20M \
+	PHP_MAX_EXECUTION_TIME=300
+
 # Download package and extract to web volume
 RUN curl -o mautic.zip -SL https://github.com/mautic/mautic/releases/download/${MAUTIC_VERSION}/${MAUTIC_VERSION}.zip \
 	&& echo "$MAUTIC_SHA1 *mautic.zip" | sha1sum -c - \

--- a/beta-fpm/docker-entrypoint.sh
+++ b/beta-fpm/docker-entrypoint.sh
@@ -4,8 +4,11 @@ set -e
 if [ ! -f /usr/local/etc/php/php.ini ]; then
 	cat <<EOF > /usr/local/etc/php/php.ini
 date.timezone = "${PHP_INI_DATE_TIMEZONE}"
+always_populate_raw_post_data = -1
 memory_limit = ${PHP_MEMORY_LIMIT}
+file_uploads = On
 upload_max_filesize = ${PHP_MAX_UPLOAD}
+post_max_size = ${PHP_MAX_UPLOAD}
 max_execution_time = ${PHP_MAX_EXECUTION_TIME}
 EOF
 fi

--- a/beta-fpm/docker-entrypoint.sh
+++ b/beta-fpm/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+if [ ! -f /usr/local/etc/php/php.ini ]; then
+	cat <<EOF > /usr/local/etc/php/php.ini
+date.timezone = "${PHP_INI_DATE_TIMEZONE}"
+memory_limit = ${PHP_MEMORY_LIMIT}
+upload_max_filesize = ${PHP_MAX_UPLOAD}
+max_execution_time = ${PHP_MAX_EXECUTION_TIME}
+EOF
+fi
+
+
 if [ -n "$MYSQL_PORT_3306_TCP" ]; then
         if [ -z "$MAUTIC_DB_HOST" ]; then
                 export MAUTIC_DB_HOST='mysql'
@@ -122,7 +132,6 @@ fi
 
 echo >&2
 echo >&2 "========================================================================"
-
 
 
 # Github Pull Tester

--- a/beta-fpm/makeconfig.php
+++ b/beta-fpm/makeconfig.php
@@ -33,6 +33,10 @@ if(array_key_exists('MAUTIC_TRUSTED_PROXIES', $_ENV)) {
     $parameters['trusted_proxies'] = $proxies;
 }
 
+if(array_key_exists('PHP_INI_DATE_TIMEZONE', $_ENV)) {
+    $parameters['default_timezone'] = $_ENV['PHP_INI_DATE_TIMEZONE'];
+}
+
 $path     = '/var/www/html/app/config/local.php';
 $rendered = "<?php\n\$parameters = ".var_export($parameters, true).";\n";
 

--- a/beta-fpm/mautic-php.ini
+++ b/beta-fpm/mautic-php.ini
@@ -1,5 +1,0 @@
-always_populate_raw_post_data = -1
-memory_limit = 512M
-file_uploads = On
-upload_max_filesize=128M
-post_max_size=128M

--- a/common/docker-entrypoint.sh
+++ b/common/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+if [ ! -f /usr/local/etc/php/php.ini ]; then
+	cat <<EOF > /usr/local/etc/php/php.ini
+date.timezone = "${PHP_INI_DATE_TIMEZONE}"
+memory_limit = ${PHP_MEMORY_LIMIT}
+upload_max_filesize = ${PHP_MAX_UPLOAD}
+max_execution_time = ${PHP_MAX_EXECUTION_TIME}
+EOF
+fi
+
+
 if [ -n "$MYSQL_PORT_3306_TCP" ]; then
         if [ -z "$MAUTIC_DB_HOST" ]; then
                 export MAUTIC_DB_HOST='mysql'
@@ -13,7 +23,6 @@ if [ -n "$MYSQL_PORT_3306_TCP" ]; then
                 echo >&2 "  instead of the linked mysql container"
         fi
 fi
-
 
 
 if [ -z "$MAUTIC_DB_HOST" ]; then

--- a/common/docker-entrypoint.sh
+++ b/common/docker-entrypoint.sh
@@ -4,8 +4,11 @@ set -e
 if [ ! -f /usr/local/etc/php/php.ini ]; then
 	cat <<EOF > /usr/local/etc/php/php.ini
 date.timezone = "${PHP_INI_DATE_TIMEZONE}"
+always_populate_raw_post_data = -1
 memory_limit = ${PHP_MEMORY_LIMIT}
+file_uploads = On
 upload_max_filesize = ${PHP_MAX_UPLOAD}
+post_max_size = ${PHP_MAX_UPLOAD}
 max_execution_time = ${PHP_MAX_EXECUTION_TIME}
 EOF
 fi

--- a/common/makeconfig.php
+++ b/common/makeconfig.php
@@ -36,6 +36,10 @@ if(array_key_exists('MAUTIC_TRUSTED_PROXIES', $_ENV)) {
     $parameters['trusted_proxies'] = $proxies;
 }
 
+if(array_key_exists('PHP_INI_DATE_TIMEZONE', $_ENV)) {
+    $parameters['default_timezone'] = $_ENV['PHP_INI_DATE_TIMEZONE'];
+}
+
 $path     = '/var/www/html/app/config/local.php';
 $rendered = "<?php\n\$parameters = ".var_export($parameters, true).";\n";
 

--- a/common/mautic-php.ini
+++ b/common/mautic-php.ini
@@ -1,5 +1,0 @@
-always_populate_raw_post_data = -1
-memory_limit = 512M
-file_uploads = On
-upload_max_filesize=128M
-post_max_size=128M

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -45,8 +45,8 @@ ENV MAUTIC_DB_NAME mautic
 
 # Setting PHP properties
 ENV PHP_INI_DATE_TIMEZONE='UTC' \
-	PHP_MEMORY_LIMIT=256M \
-	PHP_MAX_UPLOAD=20M \
+	PHP_MEMORY_LIMIT=512M \
+	PHP_MAX_UPLOAD=128M \
 	PHP_MAX_EXECUTION_TIME=300
 
 # Download package and extract to web volume
@@ -63,7 +63,6 @@ COPY makeconfig.php /makeconfig.php
 COPY makedb.php /makedb.php
 COPY mautic.crontab /etc/cron.d/mautic
 RUN chmod 644 /etc/cron.d/mautic
-COPY mautic-php.ini /usr/local/etc/php/conf.d/mautic-php.ini
 
 # Apply necessary permissions
 RUN ["chmod", "+x", "/entrypoint.sh"]

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -43,6 +43,12 @@ ENV MAUTIC_RUN_CRON_JOBS true
 ENV MAUTIC_DB_USER root
 ENV MAUTIC_DB_NAME mautic
 
+# Setting PHP properties
+ENV PHP_INI_DATE_TIMEZONE='UTC' \
+	PHP_MEMORY_LIMIT=256M \
+	PHP_MAX_UPLOAD=20M \
+	PHP_MAX_EXECUTION_TIME=300
+
 # Download package and extract to web volume
 RUN curl -o mautic.zip -SL https://github.com/mautic/mautic/releases/download/${MAUTIC_VERSION}/${MAUTIC_VERSION}.zip \
 	&& echo "$MAUTIC_SHA1 *mautic.zip" | sha1sum -c - \

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -4,8 +4,11 @@ set -e
 if [ ! -f /usr/local/etc/php/php.ini ]; then
 	cat <<EOF > /usr/local/etc/php/php.ini
 date.timezone = "${PHP_INI_DATE_TIMEZONE}"
+always_populate_raw_post_data = -1
 memory_limit = ${PHP_MEMORY_LIMIT}
+file_uploads = On
 upload_max_filesize = ${PHP_MAX_UPLOAD}
+post_max_size = ${PHP_MAX_UPLOAD}
 max_execution_time = ${PHP_MAX_EXECUTION_TIME}
 EOF
 fi

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+if [ ! -f /usr/local/etc/php/php.ini ]; then
+	cat <<EOF > /usr/local/etc/php/php.ini
+date.timezone = "${PHP_INI_DATE_TIMEZONE}"
+memory_limit = ${PHP_MEMORY_LIMIT}
+upload_max_filesize = ${PHP_MAX_UPLOAD}
+max_execution_time = ${PHP_MAX_EXECUTION_TIME}
+EOF
+fi
+
+
 if [ -n "$MYSQL_PORT_3306_TCP" ]; then
         if [ -z "$MAUTIC_DB_HOST" ]; then
                 export MAUTIC_DB_HOST='mysql'

--- a/fpm/makeconfig.php
+++ b/fpm/makeconfig.php
@@ -36,6 +36,10 @@ if(array_key_exists('MAUTIC_TRUSTED_PROXIES', $_ENV)) {
     $parameters['trusted_proxies'] = $proxies;
 }
 
+if(array_key_exists('PHP_INI_DATE_TIMEZONE', $_ENV)) {
+    $parameters['default_timezone'] = $_ENV['PHP_INI_DATE_TIMEZONE'];
+}
+
 $path     = '/var/www/html/app/config/local.php';
 $rendered = "<?php\n\$parameters = ".var_export($parameters, true).";\n";
 

--- a/fpm/mautic-php.ini
+++ b/fpm/mautic-php.ini
@@ -1,5 +1,0 @@
-always_populate_raw_post_data = -1
-memory_limit = 512M
-file_uploads = On
-upload_max_filesize=128M
-post_max_size=128M


### PR DESCRIPTION
:sparkles: Add PHP.ini setup to fix #78 & fix #69
* Instead of copying sample php.ini file, generate one inside entrypoint
* Initialize php.ini with env variables
