### PR TITLE
make port 80 redirect to SSL

### DIFF
--- a/examples/mautic-example-nginx-ssl/docker-compose.yml
+++ b/examples/mautic-example-nginx-ssl/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: mautic/mautic
     depends_on:
       - mysql
-    ports:
-      - "80:80"
     environment:
       MAUTIC_DB_HOST: mysql
       MAUTIC_DB_USER: mautic
@@ -22,6 +20,7 @@ services:
   nginx:
     image: nginx
     ports:
+      - "80:80"
       - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf

--- a/examples/mautic-example-nginx-ssl/nginx.conf
+++ b/examples/mautic-example-nginx-ssl/nginx.conf
@@ -6,10 +6,10 @@ server {
 }
 
 server {
-	listen 443 ssl;
+    listen 443 ssl;
     ssl_certificate     /etc/ssl/private/mautic.crt;
     ssl_certificate_key /etc/ssl/private/mautic.key;
-	location / {
+    location / {
         proxy_set_header        Host               $host;
         proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
         proxy_set_header        X-Forwarded-Proto  $scheme;
@@ -19,10 +19,10 @@ server {
         proxy_set_header        Forwarded   "";
         proxy_set_header        X-Real-IP   "";
         proxy_set_header        X-Forwarded-Host "";
-		
+
         proxy_pass http://mautic/;
 
         # sometimes apache mod_rewrite redirects to absolute http:// urls. Replace those with https:// urls
         proxy_redirect http:// https://;
-	}
+    }
 }

--- a/examples/mautic-example-nginx-ssl/nginx.conf
+++ b/examples/mautic-example-nginx-ssl/nginx.conf
@@ -1,4 +1,11 @@
 server {
+    listen 80;
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
 	listen 443 ssl;
     ssl_certificate     /etc/ssl/private/mautic.crt;
     ssl_certificate_key /etc/ssl/private/mautic.key;


### PR DESCRIPTION
These days it's generally accepted that best practice is to use SSL
everywhere, since unencrypted traffic is susceptible to all kinds of
security and privacy issues.