### PR TITLE
add named volumes for mysql and mautic

### DIFF
--- a/examples/mautic-example-nginx-ssl/docker-compose.yml
+++ b/examples/mautic-example-nginx-ssl/docker-compose.yml
@@ -11,6 +11,9 @@ services:
       MAUTIC_DB_USER: mautic
       MAUTIC_DB_PASSWORD: mauticdbpass
       MAUTIC_TRUSTED_PROXIES: 0.0.0.0/0
+    volumes:
+      - mautic-web:/var/www/html
+
   mysql:
     image: mysql:5.6
     environment:
@@ -18,6 +21,8 @@ services:
       MYSQL_DATABASE: mautic
       MYSQL_USER: mautic
       MYSQL_PASSWORD: mauticdbpass
+    volumes:
+      - mysql:/var/lib/mysql
 
   nginx:
     image: nginx
@@ -41,4 +46,6 @@ services:
       exec nginx -g 'daemon off;'"
 
 volumes:
+  mautic-web:
   sslcerts:
+  mysql:


### PR DESCRIPTION
When sysadmins type commands like `docker volume ls`, it`s more helpful for them to see volume names like `mysql` and `mautic-web` than enormously long hex digests like

  a25ef6f3c3518858eda30aeb2c831e95f9689c8f4a166985c42aca9b759bd255

So used named volumes rather than letting Docker pick its own names.