### PR TITLE
fix inconsistent indentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can access and customize Docker Mautic from [Official Docker Hub image](http
 
 If you want yo pull the latest stable image from DockerHub:
 
-	docker pull mautic/mautic:latest
+    docker pull mautic/mautic:latest
 
 There are also another images that fit your needs:
 
@@ -32,9 +32,9 @@ There are also another images that fit your needs:
 
 Setting up MySQL Server:
 
-	$ docker volume create mysql_data
+    $ docker volume create mysql_data
 
-	$ docker run --name percona -d \
+    $ docker run --name percona -d \
         -p 3306:3306 \
         -e MYSQL_ROOT_PASSWORD=mypassword \
         -v mysql_data:/var/lib/mysql \
@@ -43,9 +43,9 @@ Setting up MySQL Server:
 
 Running Mautic:
 
-	$ docker volume create mautic_data
+    $ docker volume create mautic_data
 
-	$ docker run --name mautic -d \
+    $ docker run --name mautic -d \
         --restart=always \
         -e MAUTIC_DB_HOST=127.0.0.1 \
         -e MAUTIC_DB_USER=root \
@@ -64,11 +64,11 @@ This will run a basic mysql service within Mautic on http://localhost:8080.
 The following environment variables are also honored for configuring your Mautic instance:
 
 #### Database Options
--	`-e MAUTIC_DB_HOST=...` (defaults to the IP and port of the linked `mysql` container)
--	`-e MAUTIC_DB_USER=...` (defaults to "root")
--	`-e MAUTIC_DB_PASSWORD=...` (defaults to the value of the `MYSQL_ROOT_PASSWORD` environment variable from the linked `mysql` container)
--	`-e MAUTIC_DB_NAME=...` (defaults to "mautic")
--	`-e MAUTIC_DB_TABLE_PREFIX=...` (defaults to empty) Add prefix do Mautic Tables. Very useful when migrate existing databases from another server to docker.
+-   `-e MAUTIC_DB_HOST=...` (defaults to the IP and port of the linked `mysql` container)
+-   `-e MAUTIC_DB_USER=...` (defaults to "root")
+-   `-e MAUTIC_DB_PASSWORD=...` (defaults to the value of the `MYSQL_ROOT_PASSWORD` environment variable from the linked `mysql` container)
+-   `-e MAUTIC_DB_NAME=...` (defaults to "mautic")
+-   `-e MAUTIC_DB_TABLE_PREFIX=...` (defaults to empty) Add prefix do Mautic Tables. Very useful when migrate existing databases from another server to docker.
 
 If you'd like to use an external database instead of a linked `mysql` container, specify the hostname and port with `MAUTIC_DB_HOST` along with the password in `MAUTIC_DB_PASSWORD` and the username in `MAUTIC_DB_USER` (if it is something other than `root`).
 
@@ -76,17 +76,17 @@ If you'd like to use an external database instead of a linked `mysql` container,
 If the `MAUTIC_DB_NAME` specified does not already exist on the given MySQL server, it will be created automatically upon startup of the `mautic` container, provided that the `MAUTIC_DB_USER` specified has the necessary permissions to create it.
 
 ### Mautic Options
--	`-e MAUTIC_RUN_CRON_JOBS=...` (defaults to true - enabled) If set to true runs mautic cron jobs using included cron daemon
--	`-e MAUTIC_TRUSTED_PROXIES=...` (defaults to empty) If it's Mautic behing a reverse proxy you can set a list of comma separated CIDR network addresses it sets those addreses as trusted proxies. You can use `0.0.0.0/0` or See [documentation](http://symfony.com/doc/current/request/load_balancer_reverse_proxy.html)
--	`-e MAUTIC_CRON_HUBSPOT=...` (defaults to empty) Enables mautic crons for Hubspot CRM integration
--	`-e MAUTIC_CRON_SALESFORCE=...` (defaults to empty) Enables mautic crons for Salesforce integration
--	`-e MAUTIC_CRON_PIPEDRIVE=...` (defaults to empty) Enables mautic crons for Pipedrive CRM integration
--	`-e MAUTIC_CRON_ZOHO=...` (defaults to empty) Enables mautic crons for Zoho CRM integration
--	`-e MAUTIC_CRON_SUGARCRM=...` (defaults to empty) Enables mautic crons for SugarCRM integration
--	`-e MAUTIC_CRON_DYNAMICS=...` (defaults to empty) Enables mautic crons for Dynamics CRM integration
+-   `-e MAUTIC_RUN_CRON_JOBS=...` (defaults to true - enabled) If set to true runs mautic cron jobs using included cron daemon
+-   `-e MAUTIC_TRUSTED_PROXIES=...` (defaults to empty) If it's Mautic behing a reverse proxy you can set a list of comma separated CIDR network addresses it sets those addreses as trusted proxies. You can use `0.0.0.0/0` or See [documentation](http://symfony.com/doc/current/request/load_balancer_reverse_proxy.html)
+-   `-e MAUTIC_CRON_HUBSPOT=...` (defaults to empty) Enables mautic crons for Hubspot CRM integration
+-   `-e MAUTIC_CRON_SALESFORCE=...` (defaults to empty) Enables mautic crons for Salesforce integration
+-   `-e MAUTIC_CRON_PIPEDRIVE=...` (defaults to empty) Enables mautic crons for Pipedrive CRM integration
+-   `-e MAUTIC_CRON_ZOHO=...` (defaults to empty) Enables mautic crons for Zoho CRM integration
+-   `-e MAUTIC_CRON_SUGARCRM=...` (defaults to empty) Enables mautic crons for SugarCRM integration
+-   `-e MAUTIC_CRON_DYNAMICS=...` (defaults to empty) Enables mautic crons for Dynamics CRM integration
 
 ### Enable / Disable Features
--	`-e MAUTIC_TESTER=...` (defaults to empty) Enables Mautic Github Pull Tester  [documentation](https://github.com/mautic/mautic-tester)
+-   `-e MAUTIC_TESTER=...` (defaults to empty) Enables Mautic Github Pull Tester  [documentation](https://github.com/mautic/mautic-tester)
 
 
 ### Persistent Data Volumes
@@ -109,24 +109,24 @@ Access your new Mautic on `http://localhost:8080` or `http://host-ip:8080` in a 
 
 Example `docker-compose.yml` for `mautic`:
 
-	mautic:
-	  image: mautic/mautic:latest
-	  links:
-	    - mauticdb:mysql
-	  ports:
-	    - 8080:80
-		volumes:
-	    - mautic_data:/var/www/html
-		environment:
-	    - MAUTIC_DB_HOST=127.0.0.1
-	    - MAUTIC_DB_USER=root
-	    - MAUTIC_DB_PASSWORD=mysecret
-	    - MAUTIC_DB_NAME=mautic
+    mautic:
+      image: mautic/mautic:latest
+      links:
+        - mauticdb:mysql
+      ports:
+        - 8080:80
+      volumes:
+        - mautic_data:/var/www/html
+      environment:
+        - MAUTIC_DB_HOST=127.0.0.1
+        - MAUTIC_DB_USER=root
+        - MAUTIC_DB_PASSWORD=mysecret
+        - MAUTIC_DB_NAME=mautic
 
-	mauticdb:
-	  image: mysql:5.6
-	  environment:
-	    MYSQL_ROOT_PASSWORD=mysecret
+    mauticdb:
+      image: mysql:5.6
+      environment:
+        MYSQL_ROOT_PASSWORD=mysecret
 
 Run `docker-compose up`, wait for it to initialize completely, and visit `http://localhost:8080` or `http://host-ip:8080`.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If the `MAUTIC_DB_NAME` specified does not already exist on the given MySQL serv
 
 ### Mautic Options
 -   `-e MAUTIC_RUN_CRON_JOBS=...` (defaults to true - enabled) If set to true runs mautic cron jobs using included cron daemon
--   `-e MAUTIC_TRUSTED_PROXIES=...` (defaults to empty) If it's Mautic behing a reverse proxy you can set a list of comma separated CIDR network addresses it sets those addreses as trusted proxies. You can use `0.0.0.0/0` or See [documentation](http://symfony.com/doc/current/request/load_balancer_reverse_proxy.html)
+-   `-e MAUTIC_TRUSTED_PROXIES=...` (defaults to empty) If it's Mautic behind a reverse proxy you can set a list of comma-separated CIDR network addresses it sets those addresses as trusted proxies. You can use `0.0.0.0/0` or See [documentation](http://symfony.com/doc/current/request/load_balancer_reverse_proxy.html)
 -   `-e MAUTIC_CRON_HUBSPOT=...` (defaults to empty) Enables mautic crons for Hubspot CRM integration
 -   `-e MAUTIC_CRON_SALESFORCE=...` (defaults to empty) Enables mautic crons for Salesforce integration
 -   `-e MAUTIC_CRON_PIPEDRIVE=...` (defaults to empty) Enables mautic crons for Pipedrive CRM integration


### PR DESCRIPTION
It was a mix of tabs and spaces, and the tabs were obviously meant to be interpreted as being 4 columns wide, which is a much less common interpretation than 8 columns.  So make the file self-consistent and unambiguous by replacing each tab with 4 spaces.

Then fix a couple of issues with indentation in the example `docker-compose` file.