### PR TITLE
Fix docker-compose syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,24 +109,27 @@ Access your new Mautic on `http://localhost:8080` or `http://host-ip:8080` in a 
 
 Example `docker-compose.yml` for `mautic`:
 
-	mautic:
-	  image: mautic/mautic:latest
-	  links:
-	    - mauticdb:mysql
-	  ports:
-	    - 8080:80
-		volumes:
-	    - mautic_data:/var/www/html
-		environment:
-	    - MAUTIC_DB_HOST=127.0.0.1
-	    - MAUTIC_DB_USER=root
-	    - MAUTIC_DB_PASSWORD=mysecret
-	    - MAUTIC_DB_NAME=mautic
+	version: '2'
+	services:
+	  mautic:
+	    image: mautic/mautic:latest
+	    links:
+	      - mauticdb
+	    ports:
+	      - 8080:80
+	    # Uncommend if need to persist data in host volumens or for development purposes 
+	    # volumes:      
+	    #   - mautic_data:/var/www/html
+	    environment:
+	      - MAUTIC_DB_HOST=mauticdb
+	      - MAUTIC_DB_USER=root
+	      - MAUTIC_DB_PASSWORD=mysecret
+	      - MAUTIC_DB_NAME=mautic
 
-	mauticdb:
-	  image: mysql:5.6
-	  environment:
-	    MYSQL_ROOT_PASSWORD=mysecret
+	  mauticdb:
+	    image: mysql:5.6
+	    environment:
+	      MYSQL_ROOT_PASSWORD=mysecret
 
 Run `docker-compose up`, wait for it to initialize completely, and visit `http://localhost:8080` or `http://host-ip:8080`.
 


### PR DESCRIPTION
the docker-compose had multiple syntax and indentation errors, it was missing the version and services block and part of the mautic service parameters where indented with tabs, also the database link had an unnecessary name tag and the database host env var was referring to localhost instead of the DB service linked to it. Also there is a volume linked to a data folder that doesn't apply to most cases and is not referred to in this readme, if a "plug and play" installation is intended, is best to use the data folder in the image and explain, if data persistence is needed, then other configs must be performed.