### PR TITLE
Error when you try to use docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Example `docker-compose.yml` for `mautic`:
     mauticdb:
       image: mysql:5.6
       environment:
-        MYSQL_ROOT_PASSWORD=mysecret
+        - MYSQL_ROOT_PASSWORD=mysecret
 
 Run `docker-compose up`, wait for it to initialize completely, and visit `http://localhost:8080` or `http://host-ip:8080`.
 


### PR DESCRIPTION
ERROR: The Compose file './docker-compose.yml' is invalid because:
mauticdb.environment contains an invalid type, it should be an object, or an array