### PR TITLE
Adding hostname to mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Example `docker-compose.yml` for `mautic`:
       volumes:
         - mautic_data:/var/www/html
       environment:
-        - MAUTIC_DB_HOST=127.0.0.1
+        - MAUTIC_DB_HOST=mauticdb
         - MYSQL_PORT_3306_TCP=3306
         - MAUTIC_DB_USER=root
         - MAUTIC_DB_PASSWORD=mysecret
@@ -126,6 +126,7 @@ Example `docker-compose.yml` for `mautic`:
 
     mauticdb:
       image: mysql:5.6
+      hostname: mauticdb
       environment:
         - MYSQL_ROOT_PASSWORD=mysecret
 


### PR DESCRIPTION
Docker Compose example is not executable out of the box.
Adding a hostname to the mysql container allows the mautic container to connect via the hostname.
This makes it a better example.