### PR TITLE
update readme: included volumes for docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ services:
     networks:
       - mautic-net
 
+volumes:
+  mysql_data:
+    driver: local
+  mautic_data:
+    driver: local
 networks:
   mautic-net:
     driver: bridge


### PR DESCRIPTION
Docker compose file example in Read Me doesn't have volumes defined so doesn't work when you try using it.

Added volumes