### PR TITLE
enable ssl connection for db in apache docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following environment variables are also honored for configuring your Mautic
 -   `-e MAUTIC_DB_PASSWORD=...` (defaults to the value of the `MYSQL_ROOT_PASSWORD` environment variable from the linked `mysql` container)
 -   `-e MAUTIC_DB_NAME=...` (defaults to "mautic")
 -   `-e MAUTIC_DB_TABLE_PREFIX=...` (defaults to empty) Add prefix do Mautic Tables. Very useful when migrate existing databases from another server to docker.
+-   `-e MAUTIC_DB_SSL_CA_CERT=...` (defaults to empty) Set the path to the CA Cert to enable SSL connection to the database. You have the responsability to provide the CA cert yourself (thanks to a volume for example)
 
 If you'd like to use an external database instead of a linked `mysql` container, specify the hostname and port with `MAUTIC_DB_HOST` along with the password in `MAUTIC_DB_PASSWORD` and the username in `MAUTIC_DB_USER` (if it is something other than `root`).
 

--- a/apache/makedb.php
+++ b/apache/makedb.php
@@ -1,5 +1,5 @@
 <?php
-// Args: 0 => makedb.php, 1 => "$MAUTIC_DB_HOST", 2 => "$MAUTIC_DB_USER", 3 => "$MAUTIC_DB_PASSWORD", 4 => "$MAUTIC_DB_NAME"
+// Args: 0 => makedb.php, 1 => "$MAUTIC_DB_HOST", 2 => "$MAUTIC_DB_USER", 3 => "$MAUTIC_DB_PASSWORD", 4 => "$MAUTIC_DB_NAME", 5 => "$MAUTIC_DB_SSL_CA_CERT"
 $stderr = fopen('php://stderr', 'w');
 fwrite($stderr, "\nEnsuring Mautic database is present\n");
 
@@ -17,7 +17,14 @@ $maxTries = 10;
 
 do
 {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int) $port);
+	$mysql = mysqli_init();
+
+	if (!empty($argv[5])) {
+		$mysql->options(MYSQLI_OPT_SSL_VERIFY_SERVER_CERT, true);
+		$mysql->ssl_set(NULL, NULL, $argv[5], NULL, NULL);
+	}
+
+	$mysql->real_connect($host, $argv[2], $argv[3], '', (int) $port);
 
 	if ($mysql->connect_error)
 	{


### PR DESCRIPTION
I am not sure if you are interested in merging this. In the cloud most of the managed database have SSL enabled per default so it is mandatory to be able to setup ssl options in the db connection. I chose to not change the mautic base code to add this.