### PR TITLE
Mautic 4 images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Build Docker images
+
+on:
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build Apache image
+        uses: docker/build-push-action@v2
+        with:
+          context: apache
+          push: false
+          tags: mautic/docker-apache:latest
+      - name: Build FPM image
+        uses: docker/build-push-action@v2
+        with:
+          context: fpm
+          push: false
+          tags: mautic/docker-fpm:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [apache, fpm]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -13,15 +16,9 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Build Apache image
+      - name: Build ${{ matrix.image }} image
         uses: docker/build-push-action@v2
         with:
-          context: apache
+          context: ${{ matrix.image }}
           push: false
-          tags: mautic/docker-apache:latest
-      - name: Build FPM image
-        uses: docker/build-push-action@v2
-        with:
-          context: fpm
-          push: false
-          tags: mautic/docker-fpm:latest
+          tags: mautic/docker-${{ matrix.image }}:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           context: ${{ matrix.image }}
           push: false
-          tags: mautic/docker-${{ matrix.image }}:latest
+          tags: mautic/mautic:v4-${{ matrix.image }}

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If the `MAUTIC_DB_NAME` specified does not already exist on the given MySQL serv
 ### Mautic Options
 
 - `-e MAUTIC_RUN_CRON_JOBS=...` (defaults to true - enabled) If set to true runs mautic cron jobs using included cron daemon
-- `-e MAUTIC_TRUSTED_PROXIES=...` (defaults to empty) If it's Mautic behind a reverse proxy you can set a list of comma-separated CIDR network addresses it sets those addresses as trusted proxies. You can use `0.0.0.0/0` or See [documentation](http://symfony.com/doc/current/request/load_balancer_reverse_proxy.html)
+- `-e MAUTIC_TRUSTED_PROXIES=...` (defaults to empty) If Mautic sits behind a reverse proxy, you can set a json array of CIDR network addresses here, and mautic will set those addresses as trusted proxies. You can use `["0.0.0.0/0"]` or See [documentation](http://symfony.com/doc/current/request/load_balancer_reverse_proxy.html)
 - `-e MAUTIC_CRON_HUBSPOT=...` (defaults to empty) Enables mautic crons for Hubspot CRM integration
 - `-e MAUTIC_CRON_SALESFORCE=...` (defaults to empty) Enables mautic crons for Salesforce integration
 - `-e MAUTIC_CRON_PIPEDRIVE=...` (defaults to empty) Enables mautic crons for Pipedrive CRM integration
@@ -167,14 +167,14 @@ services:
 
   mautic:
     container_name: mautic
-    image: mautic/mautic:v3
+    image: mautic/mautic:v4-apache
     volumes:
       - mautic_data:/var/www/html
     environment:
       - MAUTIC_DB_HOST=database
       - MAUTIC_DB_USER=root
       - MAUTIC_DB_PASSWORD=mypassword
-      - MAUTIC_DB_NAME=mautic3
+      - MAUTIC_DB_NAME=mautic4
     restart: always
     networks:
       - mauticnet

--- a/README.md
+++ b/README.md
@@ -18,9 +18,21 @@ _This repository refers to Mautic 3 Series. If you would like information about 
 
 If you want to pull the latest **stable** image from Mautic 3 Series on DockerHub:
 
-    docker pull mautic/mautic:v3
+    docker pull mautic/mautic:v4
 
-**_Note that during the 3.0.x period, the 'mautic/mautic:latest' tag still refers to Mautic 2 for backward compatibility. If you intend to use Mautic 2, use the 'mautic/mautic:v2' tag instead of 'mautic/mautic:latest'._**
+**_Note that during the 4.0.x period, the 'mautic/mautic:latest' tag still refers to Mautic 2 for backward compatibility. If you intend to use Mautic 2, use the 'mautic/mautic:v2' tag instead of 'mautic/mautic:latest'._**
+
+If you want to pull the latest **stable** image from Mautic 4 Series on DockerHub:
+
+    docker pull mautic/mautic:v4
+
+If you want to pull the latest **stable** image based on Apache2 from Mautic 4 Series on DockerHub:
+
+    docker pull mautic/mautic:v4-apache
+
+If you want to pull the latest **stable** image based on FPM from Mautic 4 Series on DockerHub:
+
+    docker pull mautic/mautic:v4-fpm
 
 If you want to pull the latest **stable** image from Mautic 3 Series on DockerHub:
 
@@ -33,18 +45,6 @@ If you want to pull the latest **stable** image based on Apache2 from Mautic 3 S
 If you want to pull the latest **stable** image based on FPM from Mautic 3 Series on DockerHub:
 
     docker pull mautic/mautic:v3-fpm
-
-If you want to pull the latest **stable** image from Mautic 2 Series on DockerHub:
-
-    docker pull mautic/mautic:v2
-
-If you want to pull the latest **stable** image based on Apache2 from Mautic 2 Series on DockerHub:
-
-    docker pull mautic/mautic:v2-apache
-
-If you want to pull the latest **stable** image based on FPM from Mautic 2 Series on DockerHub:
-
-    docker pull mautic/mautic:v2-fpm
 
 # Running Basic Container
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -54,8 +54,8 @@ RUN docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install  gd \
     && docker-php-ext-configure opcache --enable-opcache \
-    && docker-php-ext-install intl mbstring mysqli curl pdo_mysql zip opcache bcmath gd \
-    && docker-php-ext-enable intl mbstring mysqli curl pdo_mysql zip opcache bcmath gd
+    && docker-php-ext-install intl mbstring mysqli curl pdo_mysql zip opcache bcmath gd sockets \
+    && docker-php-ext-enable intl mbstring mysqli curl pdo_mysql zip opcache bcmath gd sockets
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libaprutil1-dev \
     libicu-dev \
     libfreetype6-dev \
+    libonig-dev \
     unzip \
     nano \
     zip \
@@ -50,7 +51,7 @@ RUN docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
     docker-php-ext-install imap && \
     docker-php-ext-enable imap
 
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr/lib --with-png-dir=/usr/lib --with-jpeg-dir=/usr/lib \
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install  gd \
     && docker-php-ext-configure opcache --enable-opcache \
     && docker-php-ext-install intl mbstring mysqli curl pdo_mysql zip opcache bcmath gd \

--- a/apache/makeconfig.php
+++ b/apache/makeconfig.php
@@ -35,12 +35,6 @@ if(array_key_exists('MAUTIC_DB_PASSWORD', $_ENV)) {
     $parameters['db_password'] = $_ENV['MAUTIC_DB_PASSWORD'];
 }
 
-// only if behind a reverse proxy
-if(array_key_exists('MAUTIC_TRUSTED_PROXIES', $_ENV)) {
-    $proxies = explode(',', $_ENV['MAUTIC_TRUSTED_PROXIES']);
-    $parameters['trusted_proxies'] = $proxies;
-}
-
 if(array_key_exists('PHP_INI_DATE_TIMEZONE', $_ENV)) {
     $parameters['default_timezone'] = $_ENV['PHP_INI_DATE_TIMEZONE'];
 }

--- a/common/makeconfig.php
+++ b/common/makeconfig.php
@@ -31,10 +31,6 @@ if(array_key_exists('MAUTIC_DB_USER', $_ENV)) {
 if(array_key_exists('MAUTIC_DB_PASSWORD', $_ENV)) {
     $parameters['db_password'] = $_ENV['MAUTIC_DB_PASSWORD'];
 }
-if(array_key_exists('MAUTIC_TRUSTED_PROXIES', $_ENV)) {
-    $proxies = explode(',', $_ENV['MAUTIC_TRUSTED_PROXIES']);
-    $parameters['trusted_proxies'] = $proxies;
-}
 
 if(array_key_exists('PHP_INI_DATE_TIMEZONE', $_ENV)) {
     $parameters['default_timezone'] = $_ENV['PHP_INI_DATE_TIMEZONE'];

--- a/examples/mautic-example-nginx-ssl/docker-compose.yml
+++ b/examples/mautic-example-nginx-ssl/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
   mautic:
     restart: unless-stopped
-    image: mautic/mautic
+    image: mautic/mautic:v4-apache
     depends_on:
       - mysql
     ports:
@@ -11,7 +11,7 @@ services:
       MAUTIC_DB_HOST: mysql
       MAUTIC_DB_USER: mautic
       MAUTIC_DB_PASSWORD: mauticdbpass
-      MAUTIC_TRUSTED_PROXIES: 0.0.0.0/0
+      MAUTIC_TRUSTED_PROXIES: '["0.0.0.0/0"]'
     volumes:
       - mautic-web:/var/www/html
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -27,8 +27,8 @@ RUN pecl install mcrypt-1.0.3
 
 RUN docker-php-ext-configure imap --with-imap --with-imap-ssl --with-kerberos \
     && docker-php-ext-configure opcache --enable-opcache \
-    && docker-php-ext-install imap intl mbstring mysqli pdo_mysql zip opcache bcmath \
-    && docker-php-ext-enable imap intl mbstring mcrypt mysqli pdo_mysql zip opcache bcmath
+    && docker-php-ext-install imap intl mbstring mysqli pdo_mysql zip opcache bcmath sockets \
+    && docker-php-ext-enable imap intl mbstring mcrypt mysqli pdo_mysql zip opcache bcmath sockets
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libzip-dev \
     libssl-dev \
     libz-dev \
+    libonig-dev \
     unzip \
     zip \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/fpm/makeconfig.php
+++ b/fpm/makeconfig.php
@@ -31,10 +31,6 @@ if(array_key_exists('MAUTIC_DB_USER', $_ENV)) {
 if(array_key_exists('MAUTIC_DB_PASSWORD', $_ENV)) {
     $parameters['db_password'] = $_ENV['MAUTIC_DB_PASSWORD'];
 }
-if(array_key_exists('MAUTIC_TRUSTED_PROXIES', $_ENV)) {
-    $proxies = explode(',', $_ENV['MAUTIC_TRUSTED_PROXIES']);
-    $parameters['trusted_proxies'] = $proxies;
-}
 
 if(array_key_exists('PHP_INI_DATE_TIMEZONE', $_ENV)) {
     $parameters['default_timezone'] = $_ENV['PHP_INI_DATE_TIMEZONE'];


### PR DESCRIPTION
Fixes the builds for Mautic 4 (already bumped PHP version to 7.4 and Mautic version to 4.0.0-alpha1 in https://github.com/mautic/docker-mautic/commit/6d994c354d50598003958a34ec136b206738a424)

Added the `sockets` extension because while I was playing with Mautic from Git (composer installation), I ran into

```
  Problem 1
    - php-amqplib/php-amqplib is locked to version v3.0.0 and an update of this package was not requested.
    - php-amqplib/php-amqplib v3.0.0 requires ext-sockets * -> it is missing from your system. Install or enable PHP's sockets extension.
  Problem 2
    - php-amqplib/php-amqplib v3.0.0 requires ext-sockets * -> it is missing from your system. Install or enable PHP's sockets extension.
    - php-amqplib/rabbitmq-bundle 2.6.0 requires php-amqplib/php-amqplib ^2.12.2|^3.0 -> satisfiable by php-amqplib/php-amqplib[v3.0.0].
    - php-amqplib/rabbitmq-bundle is locked to version 2.6.0 and an update of this package was not requested.
```

The only missing piece is that the installer can't be opened due to an issue with `MAUTIC_TRUSTED_PROXIES` - would appreciate if someone could look into this!

```
mautic_1  | [Tue May 04 20:18:28.751872 2021] [php7:notice] [pid 43] [client 172.27.0.1:46774] Symfony\\Component\\DependencyInjection\\Exception\\RuntimeException: Invalid JSON in env var "resolve:MAUTIC_TRUSTED_PROXIES": Syntax error - in file /var/www/html/vendor/symfony/dependency-injection/EnvVarProcessor.php - at line 230
```

![image](https://user-images.githubusercontent.com/17739158/117064773-eb1f6d80-ad26-11eb-99c3-2e9302214a36.png)
