### PR TITLE
Add exif module to php extensions

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -54,8 +54,8 @@ RUN docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install  gd \
     && docker-php-ext-configure opcache --enable-opcache \
-    && docker-php-ext-install intl mbstring mysqli curl pdo_mysql zip opcache bcmath gd sockets \
-    && docker-php-ext-enable intl mbstring mysqli curl pdo_mysql zip opcache bcmath gd sockets
+    && docker-php-ext-install intl mbstring mysqli curl pdo_mysql zip opcache bcmath gd sockets exif \
+    && docker-php-ext-enable intl mbstring mysqli curl pdo_mysql zip opcache bcmath gd sockets exif
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -27,8 +27,8 @@ RUN pecl install mcrypt-1.0.3
 
 RUN docker-php-ext-configure imap --with-imap --with-imap-ssl --with-kerberos \
     && docker-php-ext-configure opcache --enable-opcache \
-    && docker-php-ext-install imap intl mbstring mysqli pdo_mysql zip opcache bcmath sockets \
-    && docker-php-ext-enable imap intl mbstring mcrypt mysqli pdo_mysql zip opcache bcmath sockets
+    && docker-php-ext-install imap intl mbstring mysqli pdo_mysql zip opcache bcmath sockets exif \
+    && docker-php-ext-enable imap intl mbstring mcrypt mysqli pdo_mysql zip opcache bcmath sockets exif
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer


### PR DESCRIPTION
The exif module is needed to use 'file' field types.

Closes #197