### PR TITLE
Basic docker-compose.yml example is missing env_file for worker & cron

### DIFF
--- a/examples/basic/docker-compose.yml
+++ b/examples/basic/docker-compose.yml
@@ -55,6 +55,8 @@ services:
     volumes: *mautic-volumes
     environment:
       - DOCKER_MAUTIC_ROLE=mautic_cron
+    env_file:
+      - .mautic_env
     depends_on:
       mautic_web:
         condition: service_healthy
@@ -66,6 +68,8 @@ services:
     volumes: *mautic-volumes
     environment:
       - DOCKER_MAUTIC_ROLE=mautic_worker
+    env_file:
+      - .mautic_env
     depends_on:
       mautic_web:
         condition: service_healthy


### PR DESCRIPTION
Hello Mautic team,

I'm test driving mautic 5 using the new docker image with the basic docker-compose as a starting point, and the worker and cron have trouble running without the proper MySQL credentials and therefore no emails are ever sent except for the SMTP test.

This little change fixed this issue in our mautic deployment.

Omar