### PR TITLE
Ensure mautic env vars are present for cron and worker service

### DIFF
--- a/examples/basic/docker-compose.yml
+++ b/examples/basic/docker-compose.yml
@@ -55,6 +55,8 @@ services:
     volumes: *mautic-volumes
     environment:
       - DOCKER_MAUTIC_ROLE=mautic_cron
+    env_file:
+      - .mautic_env
     depends_on:
       mautic_web:
         condition: service_healthy
@@ -66,6 +68,8 @@ services:
     volumes: *mautic-volumes
     environment:
       - DOCKER_MAUTIC_ROLE=mautic_worker
+    env_file:
+      - .mautic_env
     depends_on:
       mautic_web:
         condition: service_healthy

--- a/examples/fpm-nginx/docker-compose.yml
+++ b/examples/fpm-nginx/docker-compose.yml
@@ -64,6 +64,8 @@ services:
     volumes: *mautic-volumes
     environment:
       - DOCKER_MAUTIC_ROLE=mautic_cron
+    env_file:
+      - .mautic_env
     depends_on:
       mautic_web:
         condition: service_healthy
@@ -75,6 +77,8 @@ services:
     volumes: *mautic-volumes
     environment:
       - DOCKER_MAUTIC_ROLE=mautic_worker
+    env_file:
+      - .mautic_env
     depends_on:
       mautic_web:
         condition: service_healthy

--- a/examples/rabbitmq-worker/docker-compose.yml
+++ b/examples/rabbitmq-worker/docker-compose.yml
@@ -60,6 +60,8 @@ services:
     volumes: *mautic-volumes
     environment:
       - DOCKER_MAUTIC_ROLE=mautic_cron
+    env_file:
+      - .mautic_env
     depends_on:
       mautic_web:
         condition: service_healthy
@@ -71,6 +73,8 @@ services:
     volumes: *mautic-volumes
     environment:
       - DOCKER_MAUTIC_ROLE=mautic_worker
+    env_file:
+      - .mautic_env
     depends_on:
       mautic_web:
         condition: service_healthy


### PR DESCRIPTION
The Mautic env vars are missing in the worker and cron service, which prevents them from executing their tasks properly.

This PR addresses this