### PR TITLE
delay starting cron and worker until Mautic is installed

### DIFF
--- a/common/entrypoint_mautic_cron.sh
+++ b/common/entrypoint_mautic_cron.sh
@@ -26,5 +26,11 @@ chmod 777 /tmp/stdout
 # ensure the PHP env vars are present during cronjobs
 declare -p | grep 'PHP_INI_VALUE_' > /tmp/cron.env
 
+# wait until Mautic is installed
+until php -r 'file_exists("/var/www/html/config/local.php") ? include("/var/www/html/config/local.php") : exit(1); exit(isset($parameters["site_url"]) ? 0 : 1);'; do
+	echo "Mautic not installed, waiting to start cron"
+	sleep 5
+done
+
 # run cron and print the output
 cron -f | tail -f /tmp/stdout

--- a/common/entrypoint_mautic_worker.sh
+++ b/common/entrypoint_mautic_worker.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
+# wait until Mautic is installed
+until php -r 'file_exists("/var/www/html/config/local.php") ? include("/var/www/html/config/local.php") : exit(1); exit(isset($parameters["site_url"]) ? 0 : 1);'; do
+	echo "Mautic not installed, waiting to start workers"
+	sleep 5
+done
+
 supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
Currently cron and werker service immediately start running, but this makes no sense if Mautic isn't installed yet.

This PR adds a simple check to see if Mautic is installed, by checking if the config file exists, and if so if the the `site_url` is set. This corresponds with the check that Mautic does internally when booting up.

To test this PR:
* build the apache image based in this PR
    ```
    docker build -t mautic/mautic:5-apache --build-arg MAUTIC_VERSION=5.0.3 -f apache/Dockerfile .
   ````
* go to the basic example dir
    ```
    ❯ cd examples/basic
    ```
* start the basic example
    ```
    ❯ docker compose up -d
    ```
* verify the output of the worker container
    ```
    ❯ docker compose logs mautic_worker -f --no-log-prefix
    Mautic not installed, waiting to start workers
    Mautic not installed, waiting to start workers
    Mautic not installed, waiting to start workers
    Mautic not installed, waiting to start workers
    ...
    ```
* install Mautic via the UI or CLI
    **UI**
    go to http://localhost:8001
   
     **CLI**
   ```
   docker compose exec -u www-data -w /var/www/html mautic_web php ./bin/console mautic:install http://localhost:8001 -f --admin_email=admin@example.com --admin_password=mautic
* verify the output of the worker container
    ```
    ❯ docker compose logs mautic_worker -f --no-log-prefix
    ...
    2024-02-19 21:12:49,262 INFO Set uid to user 0 succeeded
    2024-02-19 21:12:49,265 INFO supervisord started with pid 251
    2024-02-19 21:12:50,272 INFO spawned: 'messenger-consume-email_00' with pid 252
    2024-02-19 21:12:50,274 INFO spawned: 'messenger-consume-email_01' with pid 253
    2024-02-19 21:12:50,278 INFO spawned: 'messenger-consume-failed_00' with pid 254
    2024-02-19 21:12:50,280 INFO spawned: 'messenger-consume-failed_01' with pid 255
    2024-02-19 21:12:50,283 INFO spawned: 'messenger-consume-hit_00' with pid 256
    2024-02-19 21:12:50,286 INFO spawned: 'messenger-consume-hit_01' with pid 257
    ...
    ```
