### PR TITLE
Rabbitmq not working, not found vhost with name mautic/messages

### DIFF
--- a/examples/rabbitmq-worker/.mautic_env
+++ b/examples/rabbitmq-worker/.mautic_env
@@ -7,5 +7,5 @@ MAUTIC_DB_DATABASE="${MYSQL_DATABASE}"
 MAUTIC_DB_USER="${MYSQL_USER}"
 MAUTIC_DB_PASSWORD="${MYSQL_PASSWORD}"
 
-MAUTIC_MESSENGER_DSN_EMAIL="amqp://guest:guest@rabbitmq:5672/mautic/messages"
-MAUTIC_MESSENGER_DSN_HIT="amqp://guest:guest@rabbitmq:5672/mautic/messages"
+MAUTIC_MESSENGER_DSN_EMAIL="amqp://guest:guest@rabbitmq:5672/mautic"
+MAUTIC_MESSENGER_DSN_HIT="amqp://guest:guest@rabbitmq:5672/mautic"


### PR DESCRIPTION
A quick fix to queue settings, to point to correct vhost. Queue not working with current env file.