### PR TITLE
mautic6: fix npm install and regenerate asset

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -93,6 +93,17 @@ RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf
 # Enable Apache Rewrite Module
 RUN a2enmod rewrite
 
+# Node is required for rebuilding web assets
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
+RUN apt-get install -y nodejs
+RUN npm install -g npm
+
+# Rebuilt web assets
+RUN cd /var/www/html
+RUN npm install
+RUN php /var/www/html/bin/console mautic:assets:generate
+RUN php /var/www/html/bin/console cache:clear
+
 COPY ./common/docker-entrypoint.sh /entrypoint.sh
 COPY ./common/entrypoint_mautic_web.sh /entrypoint_mautic_web.sh
 COPY ./common/entrypoint_mautic_cron.sh /entrypoint_mautic_cron.sh


### PR DESCRIPTION
When I built the image and run mautic found that web-server was not responding. All requests were timed out and following log was observed after few mins.

```
[Mon Mar 31 01:05:48.996290 2025] [php:error] [pid 181:tid 181] [client 172.20.0.186:58072] PHP Fatal error:  Maximum execution time of 300 seconds exceeded in /var/www/html/docroot/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php on line 122
172.20.0.186 - - [31/Mar/2025:00:52:58 +0000] "GET /sito/wp-includes/wlwmanifest.xml HTTP/1.1" 500 0 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"
```

To fix this issue, I installed NodeJS and rebuilt the `npm` modules and regenerated assets; and it worked!