### PR TITLE
Remove Versions on Docker Compose

### DIFF
--- a/examples/basic/docker-compose.yml
+++ b/examples/basic/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 x-mautic-volumes:
   &mautic-volumes
   - ./mautic/config:/var/www/html/config:z

--- a/examples/fpm-nginx/docker-compose.yml
+++ b/examples/fpm-nginx/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 x-mautic-volumes:
   &mautic-volumes
   - ./mautic/config:/var/www/html/config:z

--- a/examples/rabbitmq-worker/docker-compose.yml
+++ b/examples/rabbitmq-worker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 x-mautic-volumes:
   &mautic-volumes
   - ./mautic/config:/var/www/html/config:z


### PR DESCRIPTION
This PR is an improvement over #299, and removes the Docker Compose version indicator for all examples.

The version indication was a requirement on legacy Docker Compose versions. Check [this](https://forums.docker.com/t/do-you-need-to-put-the-version-at-the-top-of-docker-compose-yml-file/135863) for a small explanation.