### PR TITLE
Brand new CRON

### DIFF
--- a/common/entrypoint_mautic_cron.sh
+++ b/common/entrypoint_mautic_cron.sh
@@ -9,9 +9,56 @@ SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 BASH_ENV=/tmp/cron.env
 
-* * * * * php /var/www/html/bin/console mautic:segments:update 2>&1 | tee /tmp/stdout
-* * * * * php /var/www/html/bin/console mautic:campaigns:update 2>&1 | tee /tmp/stdout
-* * * * * php /var/www/html/bin/console mautic:campaigns:trigger 2>&1 | tee /tmp/stdout
+# Segments Update - every 15 min
+0 * * * * php /var/www/html/bin/console mautic:segments:update 2>&1 | tee /tmp/stdout
+15 * * * * php /var/www/html/bin/console mautic:segments:update 2>&1 | tee /tmp/stdout
+30 * * * * php /var/www/html/bin/console mautic:segments:update 2>&1 | tee /tmp/stdout
+45 * * * * php /var/www/html/bin/console mautic:segments:update 2>&1 | tee /tmp/stdout
+
+# Campaigns Update - every 15 min
+5 * * * * php /var/www/html/bin/console mautic:campaigns:update 2>&1 | tee /tmp/stdout
+20 * * * * php /var/www/html/bin/console mautic:campaigns:update 2>&1 | tee /tmp/stdout
+35 * * * * php /var/www/html/bin/console mautic:campaigns:update 2>&1 | tee /tmp/stdout
+50 * * * * php /var/www/html/bin/console mautic:campaigns:update 2>&1 | tee /tmp/stdout
+
+# Trigger Update - every 15 min
+10 * * * * php /var/www/html/bin/console mautic:campaigns:trigger 2>&1 | tee /tmp/stdout
+25 * * * * php /var/www/html/bin/console mautic:campaigns:trigger 2>&1 | tee /tmp/stdout
+40 * * * * php /var/www/html/bin/console mautic:campaigns:trigger 2>&1 | tee /tmp/stdout
+55 * * * * php /var/www/html/bin/console mautic:campaigns:trigger 2>&1 | tee /tmp/stdout
+
+# E-mail Queue - every 1 min - fix 310
+* * * * * php /var/www/html/bin/console messenger:consume email 2>&1 | tee /tmp/stdout
+
+# Monitored E-mail - every 1 min
+#* * * * * php /var/www/html/bin/console mautic:email:fetch 2>&1 | tee /tmp/stdout
+
+# Social Monitoring - every 6 min
+#*/6 * * * * php /var/www/html/bin/console mautic:social:monitoring 2>&1 | tee /tmp/stdout
+
+# Import Contacts - every 3 min - fix 269
+#*/3 * * * * php /var/www/html/bin/console mautic:import 2>&1 | tee /tmp/stdout
+
+# Export Contacts - every 3 min
+#*/3 * * * * php /var/www/html/bin/console mautic:contacts:scheduled_export 2>&1 | tee /tmp/stdout
+
+# Webhooks - every 1 min
+#* * * * * php /var/www/html/bin/console mautic:webhooks:process 2>&1 | tee /tmp/stdout
+
+# Update MaxMind GeoLite2 IP database - every hour - fix 171
+#0 * * * * php /var/www/html/bin/console mautic:iplookup:download 2>&1 | tee /tmp/stdout
+
+# Clean up old data - at 02:01 - fix 207
+#1 2 * * * php /var/www/html/bin/console mautic:maintenance:cleanup --days-old=365 2>&1 | tee /tmp/stdout - DISABLED, MAY CAUSE DATALOSS - TBD
+
+# MaxMind CCPA compliance - at 03:02 on sunday, at 03:12 on sunday
+#2 3 * * 0 php /var/www/html/bin/console mautic:donotsell:download 2>&1 | tee /tmp/stdout
+#12 3 * * 0 php /var/www/html/bin/console mautic:max-mind:purge 2>&1 | tee /tmp/stdout
+
+# Mautic Integrations - every 13 min - READ DOCUMENTATION BEFORE ENABLING
+#*/13 * * * 0 php /var/www/html/bin/console mautic:integration:fetchleads 2>&1 | tee /tmp/stdout
+#*/13 * * * 0 php /var/www/html/bin/console mautic:integration:pushactivity 2>&1 | tee /tmp/stdout
+
 
 EOF
 fi


### PR DESCRIPTION
This PR aims to start the closure of multiple issues regarding Cron scheduling.

The old crontab didn't implement any scheduling for features that multiple Mautic users use, leading to various opened issues, and multiple problems.

When reviewing the code, you'll notice that most Cron entries are commented - that's expected. I'm planning to enable one line per week, so that we can isolate problems quickly, if necessary.

At the moment, this PR should fix error #310, which is most critical, as e-mail scheduling is completly broken without that line. I'm also improving the mandatory cron scheduling (segments update, campaigns update and trigger update), following[ Mautic's documentation](https://docs.mautic.org/en/5.x/configuration/cron_jobs.html).

**I'll kindly ask that one of the maintainer manually triggers the build for 5.2.5, checking all three boxes, so that the changes can take place once merged.** - at least while we discuss automatic pipeline builds.