### PR TITLE
fix: remove message:consume from cron

### DIFF
--- a/common/entrypoint_mautic_cron.sh
+++ b/common/entrypoint_mautic_cron.sh
@@ -27,9 +27,6 @@ BASH_ENV=/tmp/cron.env
 40 * * * * php /var/www/html/bin/console mautic:campaigns:trigger 2>&1 | tee /tmp/stdout
 55 * * * * php /var/www/html/bin/console mautic:campaigns:trigger 2>&1 | tee /tmp/stdout
 
-# E-mail Queue - every 1 min - fix 310
-* * * * * php /var/www/html/bin/console messenger:consume email 2>&1 | tee /tmp/stdout
-
 # Monitored E-mail - every 1 min
 #* * * * * php /var/www/html/bin/console mautic:email:fetch 2>&1 | tee /tmp/stdout
 


### PR DESCRIPTION
We do not need to run message:consume in the cron since it is already running as a long-lived process in the worker container

ref: #348 