### PR TITLE
fix: cron /tmp/stdout left hanging on restart

### DIFF
--- a/common/entrypoint_mautic_cron.sh
+++ b/common/entrypoint_mautic_cron.sh
@@ -55,6 +55,9 @@ fi
 crontab -u www-data /opt/mautic/cron/mautic
 
 # create the fifo file to be able to redirect cron output for non-root users
+if [ ! -p /tmp/stdout ]; then
+	rm -f /tmp/stdout
+fi
 mkfifo /tmp/stdout
 chmod 777 /tmp/stdout
 


### PR DESCRIPTION
When restarting the cron on an existing install, the `/tmp/stdout` seems to stick around, and the cron entry point attempts to create the file, causing the entry point to fail.

```
cron-1  | Mautic not installed, waiting to start cron
cron-1  | Mautic not installed, waiting to start cron
cron-1  | mkfifo: cannot create fifo '/tmp/stdout': File exists
root@mautic-test:~# docker compose logs cron -f
```