### PR TITLE
Add Security Policy and Community Health files

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,0 +1,2 @@
+github: mautic
+open_collective: mautic

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,103 @@
+The primary source of the Code of Conduct is at [mautic.org](https://www.mautic.org/code-of-conduct/) - it is reproduced here for reference.
+
+## 1. Purpose
+
+A primary goal of the Mautic community is to support you and your business in the development, use and implementation of Mautic. It’s to be inclusive and add value to the largest number of participants, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all.
+
+This code of conduct outlines our expectations for all those who participate in our community, whether in-person or online, as well as the consequences for unacceptable behavior.
+
+Your participation is contingent upon following these guidelines in all Mautic activities, including but not limited to:
+
+* Using Mautic community resources.
+* Working with other Mauticians and other Mautic community participants whether virtually or co-located.
+* Representing Mautic at public events.
+* Representing Mautic in social media (official accounts, personal accounts, Facebook pages and groups).
+* Participating in Mautic sprints and training events.
+* Participating in Mautic-related forums, mailing lists, wikis, websites, chat channels, bugs, group or person-to-person meetings, and Mautic-related correspondence.
+
+We invite all those who participate in Mautic activities online to help us create safe and positive experiences for everyone, everywhere.
+
+
+## 2. Open Source & Culture Citizenship
+
+A supplemental goal of this Code of Conduct is to increase open source and culture citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, please recognize their efforts.
+
+## 3. Welcoming to all 
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience or job role, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, national origin, citizenship and immigration status, neurodiversity, mental health or socio-economic status. 
+
+
+## 4. Expected Behavior
+
+The following behaviors are expected and requested of all community members:
+
+* Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+* Exercise consideration and respect in your speech and actions.
+* Attempt collaboration before conflict.
+* Guide conversations toward issue resolution.
+* Refrain from demeaning, discriminatory, or harassing behavior and speech.
+
+Alert Mautic team members if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+
+## 5. Unacceptable Behavior
+
+The following behaviors are considered harassment and are unacceptable within our community:
+
+* **Violence and Threats of Violence** are not acceptable - online or offline. This includes incitement of violence toward any individual, including encouraging a person to commit self-harm. This also includes posting or threatening to post other people’s personally identifying information (“doxxing”) online.
+* **Public or private harassment** is never acceptable in any form.
+* **Personal Attacks** Conflicts will inevitably arise, but frustration should never turn into a personal attack. It is not okay to insult, demean or belittle others. Attacking someone for their opinions, beliefs and ideas is not acceptable. It is important to speak directly when we disagree and when we think we need to improve, but such discussions must be conducted respectfully and professionally, remaining focused on the issue at hand.
+* **Derogatory Language** Hurtful or harmful language is never acceptable in any context related to: background, family status, gender, gender identity or expression, marital status, sex, sexual orientation, personal appearance, body size, native language, age, ability, neurodiversity, mental health, race and/or ethnicity, national origin, citizenship and immigration status, socioeconomic status, religion, geographic location.
+* **Unwelcome Sexual Attention or Physical Contact** Unwelcome sexual attention or unwelcome physical contact is not acceptable. This includes sexualized comments, jokes or imagery in interactions, communications or presentation materials, as well as inappropriate touching, groping, or sexual advances. This includes touching a person without permission, including sensitive areas such as their hair, pregnant stomach, mobility device (wheelchair, scooter, etc) or tattoos. This also includes physically blocking or intimidating another person. Physical contact or simulated physical contact (such as emojis like “kiss”) without affirmative consent is not acceptable. This includes sharing or distribution of sexualized images or text.
+* **Disruptive Behavior** Sustained disruption of events, forums, or meetings, including talks and presentations, will not be tolerated. This includes spamming community discussions with the solicitation of unwanted products or services.
+* **Influencing Disruptive Behavior** We will treat influencing or leading such activities the same way we treat the activities themselves, and thus the same consequences apply.
+* **Corporate Promotions** Sharing of demo/trial/landing page links and other corporate promotions are never permitted unless explicitly requested by a community member. The only exceptions are that the moderated [Commercial forum category](https://forum.mautic.org/c/commercial) may be used to promote opportunities which may be relevant for members of the community (for example job opportunities, freelance gigs) and Mautic Community Partners may promote their products and services on their partners page.
+* **Scraping contacts** by name or any other personally identifiable information for unsolicited communication is never acceptable in any form. 
+
+## 6. Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, we may take any action deemed appropriate, up to and including a temporary ban or permanent expulsion from the community without warning.  Examples of sanctions which may be applied include but is not limited to:
+* Verbal warnings.
+* Written warnings.
+* Temporary absence from participation.
+* Long-term absence from participation.
+* Being required to follow a conduct agreement that dictates the process of returning to the community.
+
+
+## 7. Reporting Guidelines
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify us as soon as possible by emailing info@mautic.org, or contacting a Mautic team member on the specific platform.
+
+Processes for dealing with breaches of the Code of Conduct can be found [here][coc-breaches].
+
+## 8. Addressing Grievances
+Only permanent resolutions (such as bans) may be appealed. To appeal a decision, contact the Mautic team at info@mautic.org with your appeal and the team will review the situation.
+
+## 9. Scope
+We expect all community participants (contributors, moderators and other guests) to abide by this Code of Conduct in all community venues–online and in-person–as well as in all one-on-one communications pertaining to community affairs.
+
+While this code of conduct is specifically aimed at Mautic’s official resources and community, we recognize that it is possible for actions taken outside of Mautic’s official online or in person spaces to have a deep impact on community health. 
+
+Resources or incidents which break this code of conduct for any reason in a non-Mautic community location will be considered in the same way as resources or incidents from owned channels, and subject to the same sanctions. 
+
+## 10. Contact info
+For more information, please contact info@mautic.org.
+
+## 11. License and attribution
+This Code of Conduct is directly adapted from the Stumptown Syndicate and distributed under a [Creative Commons Attribution-ShareAlike license][cc-by-sa].
+
+Additional text from [Mozilla Community Participation Guidelines][mozilla-guidelines] distributed under a [Creative Commons Attribution-ShareAlike license][cc-by-sa].
+
+Reviewed and updated using the [Mozilla Code of Conduct Assessment Tool][mozilla-tool].
+
+[coc-breaches]: </policies/code-of-conduct-breaches>
+[mozilla-guidelines]: <https://www.mozilla.org/en-US/about/governance/policies/participation/>
+[cc-by-sa]: <https://creativecommons.org/licenses/by-sa/3.0/>
+[mozilla-tool]:<https://mozilla.github.io/diversity-coc-review.io>
+
+(Code of Conduct is subject to change without notice).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to the Mautic Docker image
+It's great to see that you're interested in contributing to the Mautic Docker image! Here's some details to help you get started.
+
+## Reporting Security Vulnerabilities
+If you think that you have found a security vulnerability, please report it via the [Security Advisories section](https://github.com/mautic/docker-mautic/security/advisories/new) with as much detail as possible. The Docker Security Team will review the vulnerability and if found applicable, will assign a CVE ID and issue a fix. The vulnerability will be disclosed once the patch has been included into a release.
+
+## Getting support
+The place to get support is on the Mautic Forums. There's a category specifically for Docker support [here](https://forum.mautic.org/c/support/docker-support/112). Please ensure you provide as much detail as possible, the Docker Maintainers monitor this forum and their time is very precious.
+
+## Contributing to Mautic
+Contribution is open and available to any member of the Mautic community. All fixes and improvements are done through Pull Requests on GitHub. This code is open source and publicly available.
+
+We have five teams in the Mautic Community (Community, Education, Legal & Finance, Marketing and Product), all of whom welcome new contributors, whether code-based or low/no-code contributions.
+
+Please review our [Community Handbook](https://mau.tc/contribute) for more guidance on contributing to Mautic.
+
+To contribute on the Docker repository, please open a Pull Request and follow the template to ensure you provide the details required for testers and reviewers.
+
+## Developer Documentation
+Developer documentation is available at [https://devdocs.mautic.org](https://devdocs.mautic.org) with our legacy documentation visible at [https://developer.mautic.org](https://developer.mautic.org). To make additions or corrections to the new documentation, submit Issues or Pull Requests against [https://github.com/mautic/developer-documentation-new](https://github.com/mautic/developer-documentation-new).
+
+## User Documentation
+User documentation is available at [https://docs.mautic.org](https://docs.mautic.org). To make additions or corrections to the documentation, submit Issues or Pull Requests against [https://github.com/mautic/user-documentation](https://github.com/mautic/user-documentation).
+
+## Knowledgebase
+Knowledgebase articles can be submitted at [https://kb.mautic.org](https://kb.mautic.org), in the form of how-to articles, troubleshooting guides or tutorials.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,9 @@ The team does not directly handle:
 - Custom Docker deployments modified from the official image
 - Individual user deployment configurations
 
+## How are vulnerabilities in the underlying base image handled?
+Mautic's Docker image is automatically rebuilt every Monday at 00:00 UTC to incorporate the latest security updates from the base image and any updated Debian packages, ensuring that known vulnerabilities are addressed regularly.
+
 ## Which Docker image releases get security advisories?
 
 - Security updates will be provided for the most recent minor version of each supported major Mautic version

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,36 +27,36 @@ Mautic's Docker image is automatically rebuilt every Monday at 00:00 UTC to inco
 
 ## Which Docker image releases get security advisories?
 
-- Security updates will be provided for the most recent minor version of each supported major Mautic version
-- Development, alpha, beta, or release candidate Docker images will not receive security advisories
-- Docker images for unsupported Mautic versions will not receive security updates
+- Security updates are provided for the most recent minor version of each supported major Mautic version
+- Development, alpha, beta, or release candidate Docker images won't receive security advisories
+- Docker images for unsupported Mautic versions won't receive security updates
 
 ## How to report a Docker security issue
 
 If you discover a potential security vulnerability specific to the Mautic Docker image:
 
-1. Keep it confidential - Do not discuss it publicly in issues, pull requests, forums, or Slack
+1. Keep it confidential - Don't discuss it publicly in issues, pull requests, forums, or Slack
 2. Submit your concern as a private disclosure via GitHub's Security Advisory feature at https://github.com/mautic/docker/security
 3. Provide detailed information about the vulnerability, including steps to reproduce and potential impact
-4. If possible, you may create a private fork to propose a fix
+4. You may collaborate with the Docker Security Team a private fork to propose a fix
 
 ## How Docker security issues are resolved
 
 Mautic's Docker Security Team follow the [same process as the Mautic Security Team](https://mautic.org/security/how-security-issues-are-resolved/) when resolving issues.
 
-1. The Security Team will triage incoming reports to determine validity and severity
-2. Valid issues will be acknowledged within 24 hours and triaged within 7 business days
-3. The team will develop and test fixes for confirmed vulnerabilities within 21 business days
+1. The Security Team triages incoming reports to determine validity and severity
+2. The team aims to acknowledge valid issues within 24 hours and triage them within 7 business days
+3. The team aims to develop and test fixes for confirmed vulnerabilities within 21 business days
 4. Security patches are integrated into new Docker image builds on the 2nd and 4th Wednesdays of each month, if applicable
 5. Where an urgent fix is required, an out-of-cycle release is made in collaboration with the Mautic Security Team
-6. Coordination with the Mautic Security Team will occur when issues overlap with core application security
+6. Coordination with the Mautic Security Team occurs when issues overlap with core application security
 
 ## Security fix announcements and releases
 
 - Security fixes are announced alongside new Docker image builds
 - Critical vulnerabilities may prompt immediate out-of-sequence releases
 - Announcements include the severity, affected builds, and remediation steps
-- Users will be encouraged to update to the latest secure image version
+- Users are encouraged to update to the latest secure image version
 
 ## Disclosure policy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@
 The Mautic Docker Security Team's scope is limited to security issues specific to the official Mautic Docker image, including:
 
 - Docker image configuration
-- Base image vulnerabilities
+- PHP secure configuration best practices
 - Dockerfile security best practices
 - Container runtime security concerns
 - Docker-specific deployment guidance
@@ -50,9 +50,9 @@ Mautic's Docker Security Team follow the [same process as the Mautic Security Te
 
 ## Security fix announcements and releases
 
-- Security fixes will be announced alongside new Docker image releases
+- Security fixes are announced alongside new Docker image builds
 - Critical vulnerabilities may prompt immediate out-of-sequence releases
-- Announcements will include the severity, affected versions, and remediation steps
+- Announcements include the severity, affected builds, and remediation steps
 - Users will be encouraged to update to the latest secure image version
 
 ## Disclosure policy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,72 @@
+# Mautic's Docker Security Policy
+
+## Goals of the Mautic Docker Image Security Policy
+- Maintain a secure official Docker image for Mautic
+- Resolve reported security issues specific to the Docker image configuration
+- Provide clear documentation on securely deploying and operating the Mautic Docker image
+- Establish a transparent process for handling Docker-specific security vulnerabilities
+
+## Scope of Mautic's Docker Security Team
+The Mautic Docker Security Team's scope is limited to security issues specific to the official Mautic Docker image, including:
+
+- Docker image configuration
+- Base image vulnerabilities
+- Dockerfile security best practices
+- Container runtime security concerns
+- Docker-specific deployment guidance
+
+The team does not directly handle:
+
+- Mautic core application vulnerabilities (these are handled by the Mautic Security Team and should be raised [here](https://github.com/mautic/mautic/security/advisories/new))
+- Third-party plugins not included in the official image
+- Custom Docker deployments modified from the official image
+- Individual user deployment configurations
+
+## Which Docker image releases get security advisories?
+
+- Security updates will be provided for the most recent minor version of each supported major Mautic version
+- Development, alpha, beta, or release candidate Docker images will not receive security advisories
+- Docker images for unsupported Mautic versions will not receive security updates
+
+## How to report a Docker security issue
+
+If you discover a potential security vulnerability specific to the Mautic Docker image:
+
+1. Keep it confidential - Do not discuss it publicly in issues, pull requests, forums, or Slack
+2. Submit your concern as a private disclosure via GitHub's Security Advisory feature at https://github.com/mautic/docker/security
+3. Provide detailed information about the vulnerability, including steps to reproduce and potential impact
+4. If possible, you may create a private fork to propose a fix
+
+## How Docker security issues are resolved
+
+Mautic's Docker Security Team follow the [same process as the Mautic Security Team](https://mautic.org/security/how-security-issues-are-resolved/) when resolving issues.
+
+1. The Security Team will triage incoming reports to determine validity and severity
+2. Valid issues will be acknowledged within 24 hours and triaged within 7 business days
+3. The team will develop and test fixes for confirmed vulnerabilities within 21 business days
+4. Security fixes will be integrated into new Docker image releases on a quarterly basis, with the middle month in the quarter being security releases
+5. Where an urgent fix is required, an out-of-cycle release is made in collaboration with the Mautic Security Team
+6. Coordination with the Mautic Security Team will occur when issues overlap with core application security
+
+## Security fix announcements and releases
+
+- Security fixes will be announced alongside new Docker image releases
+- Critical vulnerabilities may prompt immediate out-of-sequence releases
+- Announcements will include the severity, affected versions, and remediation steps
+- Users will be encouraged to update to the latest secure image version
+
+## Disclosure policy
+
+Mautic's Docker Security Team follows the same Coordinated Disclosure policy as the Mautic Security Team:
+
+- Issues remain private until a fix is available
+- Public announcements occur only after secure versions are released
+- All community members should adhere to this policy when reporting issues
+
+## Team Membership
+
+Membership in the Docker Image Security Team will follow similar guidelines to those governing [joining the Mautic Security Team](https://mautic.org/security/how-to-join-the-security-team/):
+
+- Limited to individuals with proven track records in the Mautic community
+- Members should have Docker expertise and security knowledge
+- Regular participation is expected

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,7 +47,7 @@ Mautic's Docker Security Team follow the [same process as the Mautic Security Te
 1. The Security Team will triage incoming reports to determine validity and severity
 2. Valid issues will be acknowledged within 24 hours and triaged within 7 business days
 3. The team will develop and test fixes for confirmed vulnerabilities within 21 business days
-4. Security fixes will be integrated into new Docker image releases on a quarterly basis, with the middle month in the quarter being security releases
+4. Security patches are integrated into new Docker image builds on the 2nd and 4th Wednesdays of each month, if applicable
 5. Where an urgent fix is required, an out-of-cycle release is made in collaboration with the Mautic Security Team
 6. Coordination with the Mautic Security Team will occur when issues overlap with core application security
 


### PR DESCRIPTION
This PR adds:

- Security Policy (based on Mautic's with some specific parts relating to Docker)
- Contribution file to explain how to contribute
- Code of Conduct
- Funding file

Addresses https://github.com/mautic/docker-mautic/issues/336