### PR TITLE
Enable SAST to test PRs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -28,6 +28,8 @@ jobs:
           tags: mautic-${{ matrix.image_type }}
           load: true
           platforms: linux/amd64
+          build-args: |
+            MAUTIC_VERSION=5.2.5
 
       - name: Save image to tar file
         run: docker save mautic-${{ matrix.image_type }} -o image.tar

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -61,3 +61,4 @@ jobs:
           format: 'table'
           severity: 'CRITICAL,HIGH,MEDIUM'
           exit-code: '1'
+          ignore-unfixed: true # Won't fail if there isn't a fix to the CVE

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,0 +1,60 @@
+name: PR Tests
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - mautic5
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image_type: [apache, fpm]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image and export locally (for SAST scan)
+        uses: docker/build-push-action@v6
+        with:
+          file: ${{ matrix.image_type }}/Dockerfile
+          tags: mautic/mautic:${{ matrix.image_type }}-test
+          load: true 
+          platforms: linux/amd64
+
+      - name: Save image to tar file
+        run: docker save mautic/mautic:${{ matrix.image_type }}-test -o ${{ matrix.image_type }}.tar
+
+      - name: Upload image as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.image_type }}-image
+          path: ${{ matrix.image_type }}.tar
+
+  sast:
+    runs-on: ubuntu-latest
+    needs: docker-build
+
+    steps:
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.image_type }}-image
+
+      - name: Load Docker image
+        run: docker load -i ${{ matrix.image_type }}.tar
+
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+              image-ref: 'mautic/mautic:${{ matrix.image_type }}-test'
+              format: 'table'
+              severity: 'CRITICAL,HIGH,MEDIUM'
+              exit-code: '1'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -25,28 +25,31 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ${{ matrix.image_type }}/Dockerfile
-          tags: mautic-test
-          load: true 
+          tags: mautic-${{ matrix.image_type }}
+          load: true
           platforms: linux/amd64
 
       - name: Save image to tar file
-        run: docker save mautic-test -o image.tar
+        run: docker save mautic-${{ matrix.image_type }} -o image.tar
 
       - name: Upload image as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: mautic-test
+          name: mautic-${{ matrix.image_type }}
           path: image.tar
 
   sast:
     runs-on: ubuntu-latest
     needs: docker-build
+    strategy:
+      matrix:
+        image_type: [apache, fpm]
 
     steps:
       - name: Download Docker image artifact
         uses: actions/download-artifact@v4
         with:
-          name: mautic-test
+          name: mautic-${{ matrix.image_type }}
 
       - name: Load Docker image
         run: docker load -i image.tar
@@ -54,7 +57,7 @@ jobs:
       - name: Run Trivy
         uses: aquasecurity/trivy-action@0.30.0
         with:
-              image-ref: 'mmautic-test'
-              format: 'table'
-              severity: 'CRITICAL,HIGH,MEDIUM'
-              exit-code: '1'
+          image-ref: 'mautic-test-${{ matrix.image_type }}'
+          format: 'table'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '1'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -61,6 +61,6 @@ jobs:
         with:
           image-ref: 'mautic-${{ matrix.image_type }}'
           format: 'table'
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          severity: 'CRITICAL'
           exit-code: '1'
           ignore-unfixed: true # Won't fail if there isn't a fix to the CVE

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -28,8 +28,6 @@ jobs:
           tags: mautic-${{ matrix.image_type }}
           load: true
           platforms: linux/amd64
-          build-args: |
-            MAUTIC_VERSION=5.2.5
 
       - name: Save image to tar file
         run: docker save mautic-${{ matrix.image_type }} -o image.tar

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -25,18 +25,18 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ${{ matrix.image_type }}/Dockerfile
-          tags: mautic/mautic:${{ matrix.image_type }}-test
+          tags: mautic-test
           load: true 
           platforms: linux/amd64
 
       - name: Save image to tar file
-        run: docker save mautic/mautic:${{ matrix.image_type }}-test -o ${{ matrix.image_type }}.tar
+        run: docker save mautic-test -o image.tar
 
       - name: Upload image as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.image_type }}-image
-          path: ${{ matrix.image_type }}.tar
+          name: mautic-test
+          path: image.tar
 
   sast:
     runs-on: ubuntu-latest
@@ -46,15 +46,15 @@ jobs:
       - name: Download Docker image artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.image_type }}-image
+          name: mautic-test
 
       - name: Load Docker image
-        run: docker load -i ${{ matrix.image_type }}.tar
+        run: docker load -i image.tar
 
       - name: Run Trivy
         uses: aquasecurity/trivy-action@0.30.0
         with:
-              image-ref: 'mautic/mautic:${{ matrix.image_type }}-test'
+              image-ref: 'mmautic-test'
               format: 'table'
               severity: 'CRITICAL,HIGH,MEDIUM'
               exit-code: '1'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run Trivy
         uses: aquasecurity/trivy-action@0.30.0
         with:
-          image-ref: 'mautic-test-${{ matrix.image_type }}'
+          image-ref: 'mautic-${{ matrix.image_type }}'
           format: 'table'
           severity: 'CRITICAL,HIGH,MEDIUM'
           exit-code: '1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test build Docker image
 
 on:
-  pull_request:
+#  pull_request:
   schedule:
     # Run every day at 10:45 AM UTC to discover potential issues with dependencies like PHP updates etc.
     - cron: '45 10 * * *'


### PR DESCRIPTION
This pull request introduces a pipeline that automatically tests PR submissions for known vulnerabilities. If a contributor attempts to introduce a vulnerable component that could potentially be exploited in a supply chain attack, the pipeline will flag the vulnerability, causing the PR checks to fail and blocking the merge.

Currently, the SAST (Trivy) is configured to detect only critical CVEs with available patches. Over time, we plan to expand the scope of this to include lower-severity vulnerabilities, eventually covering a broader range of CVE categories, including low-severity issues.