### PR TITLE
Make Trivy ignore some vulns

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# .trivyignore
+#
+# This .trivyignore file was added due to PR #361
+# (https://github.com/mautic/docker-mautic/pull/361) for traceability.
+# The ignores below are temporary and should be revisited as upstream dependencies are updated.
+
+# Temporary ignore for package flat vulnerability until it can be properly fixed
+# Issue: Prototype Pollution vulnerability in flat 4.1.1
+CVE-2020-36632
+
+# Temporary ignore for esbuild's golang stdlib vulnerability
+# Issue: Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses
+CVE-2024-24790


### PR DESCRIPTION
This PR is necessary to be able to merge #361.

It makes Trivy ignore the following CVEs, related to outdated Mautic dependencies:
- CVE-2020-36632 (Prototype Pollution vulnerability in flat 4.1.1)
- CVE-2024-24790 (Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses)

This file must be removed after patching the dependencies on a future Mautic version.