### PR TITLE
make Trivy notice .trivyignore

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -62,3 +62,4 @@ jobs:
           severity: 'CRITICAL'
           exit-code: '1'
           ignore-unfixed: true # Won't fail if there isn't a fix to the CVE
+          trivyignores: '.trivyignore'


### PR DESCRIPTION
This PR is necessary due to Trivy issues. Related to #378.