### PR TITLE
Fix Templates Not Appearing

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -116,7 +116,6 @@ body:
       label: Additional context (Optional)
       description: Add any other context about the problem here. Screenshots, videos, or logs are welcome!
       placeholder: Anything else that might be helpful?
-      rows: 4
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,4 +1,4 @@
-name: Report a Bug
+name: Report a Docker Image Bug
 description: Report a bug related to the Docker Image
 title: "[Bug] (enter your title here) "
 labels: ["needs triage"]

--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,7 +1,7 @@
 name: Report a Bug
 description: Report a bug related to the Docker Image
 title: "[Bug] (enter your title here) "
-labels: ["needs triage"]
+labels: ["triage"]
 
 
 body:

--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,7 +1,7 @@
 name: Report a Bug
 description: Report a bug related to the Docker Image
 title: "[Bug] (enter your title here) "
-labels: ["triage"]
+labels: ["needs triage"]
 
 
 body:

--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -7,7 +7,7 @@ labels: ["triage"]
 body:
   - type: markdown
     attributes:
-      content: |
+      value: |
         ### Thank you for your bug report!
         Please provide the following details to help us quickly diagnose and resolve the issue.
 
@@ -17,7 +17,6 @@ body:
       label: Describe the bug
       description: A clear and concise description of what the bug is.
       placeholder: Tell us what you see!
-      rows: 6
     validations:
       required: true
   
@@ -33,7 +32,6 @@ body:
         3. Scroll down to '....'
         4. See error
       placeholder: What did you do to encounter the bug?
-      rows: 6
     validations:
       required: true
   
@@ -42,7 +40,6 @@ body:
     attributes:
       label: Expected behavior
       description: A clear and concise description of what you expected to happen.
-      rows: 4
     validations:
       required: true
 
@@ -51,7 +48,6 @@ body:
     attributes:
       label: Actual behavior
       description: A clear and concise description of what actually happened.
-      rows: 4
     validations:
       required: true
 
@@ -96,7 +92,6 @@ body:
       placeholder: |
         FROM mautic/mautic:latest
         # Your custom layers here...
-      rows: 10
     validations:
       required: false
 
@@ -112,7 +107,6 @@ body:
           mautic:
             image: mautic/mautic:latest
             # Your service configuration here...
-      rows: 10
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest an idea or enhancement for Mautic's Docker Image
 title: "[Feature] (enter your title here)"
-labels: ["triage"]
+labels: ["needs triage"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -6,7 +6,7 @@ labels: ["triage"]
 body:
   - type: markdown
     attributes:
-      content: |
+      value: |
         ### Share your brilliant idea!
         We appreciate your suggestions for improving the Docker Image. Please provide as much detail as possible.
 
@@ -18,7 +18,6 @@ body:
         Please provide a clear and concise description of the problem you're trying to solve.
         (e.g., "I'm always frustrated when [X] happens...")
       placeholder: What problem does this feature aim to address?
-      rows: 5
     validations:
       required: false
 
@@ -30,7 +29,6 @@ body:
         A clear and concise description of what you want to happen or how you envision the feature working.
         Be specific about how this would improve the Docker Image.
       placeholder: How would you like this feature to function?
-      rows: 8
     validations:
       required: true
 
@@ -41,7 +39,6 @@ body:
       description: |
         A clear and concise description of any alternative solutions or approaches you've thought about.
         Why did you choose your proposed solution over these alternatives?
-      rows: 4
     validations:
       required: false
 
@@ -51,7 +48,6 @@ body:
       label: Additional Context (Optional)
       description: Add any other context, screenshots, or mockups about the feature request here.
       placeholder: Anything else that might be helpful?
-      rows: 4
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest an idea or enhancement for Mautic's Docker Image
 title: "[Feature] (enter your title here)"
-labels: ["needs triage"]
+labels: ["triage"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,4 +1,4 @@
-name: Feature Request
+name: Request a Feature
 description: Suggest an idea or enhancement for Mautic's Docker Image
 title: "[Feature] (enter your title here)"
 labels: ["needs triage"]

--- a/.github/ISSUE_TEMPLATE/03-task.yml
+++ b/.github/ISSUE_TEMPLATE/03-task.yml
@@ -1,0 +1,5 @@
+---
+name: Create a Project Task
+description: This template shall be used by maintainers to create project tasks
+title: "[Task] (enter your title here)"
+---

--- a/.github/ISSUE_TEMPLATE/03-task.yml
+++ b/.github/ISSUE_TEMPLATE/03-task.yml
@@ -1,5 +1,12 @@
----
 name: Create a Project Task
 description: This template shall be used by maintainers to create project tasks
 title: "[Task] (enter your title here)"
----
+
+body:
+    - type: textarea
+      id: description
+      attributes:
+        label: Describe the task
+        description: A clear description of what the task is.
+      validations:
+        required: true

--- a/.github/ISSUE_TEMPLATE/03-task.yml
+++ b/.github/ISSUE_TEMPLATE/03-task.yml
@@ -3,10 +3,10 @@ description: This template shall be used by maintainers to create project tasks
 title: "[Task] (enter your title here)"
 
 body:
-    - type: textarea
-      id: description
-      attributes:
-        label: Describe the task
-        description: A clear description of what the task is.
-      validations:
-        required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the task
+      description: A clear description of what the task is.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Mautic Forum
     url: https://forum.mautic.org/c/support/docker-support/112
     about: Is your issue type not listed here? Checkout our forum!
-  - name: Docker Image Security
-    url: https://github.com/mautic/docker-mautic/security
-    about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Mautic Forum
-    url: https://forum.mautic.org/c/support/docker-support/112)
+    url: https://forum.mautic.org/c/support/docker-support/112
     about: Is your issue type not listed here? Checkout our forum!
   - name: Docker Image Security
     url: https://github.com/mautic/docker-mautic/security


### PR DESCRIPTION
After adding some issue templates, the repository seems to not allow people to create issues. This PR aims to fix that, by "ordering" templates and fixing tags.