### PR TITLE
Add Trivy to Publish Pipeline

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -1,8 +1,4 @@
 name: Build and publish a Docker image
-permissions:
-  contents: read
-  security-events: write
-
 
 on:
   workflow_dispatch:
@@ -34,6 +30,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
 
     steps:
       - name: Checkout repository
@@ -64,20 +61,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.30.0
-        with:
-          image-ref: 'mautic/mautic:${{ inputs.mautic_version }}-${{ matrix.image_type }}'
-          format: 'sarif'
-          ignore-unfixed: true # Won't flag on unpatchable CVEs
-          output: 'trivy-results.sarif'
-          #trivyignores: .trivyignore
-
-      - name: Upload Trivy SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-results.sarif'
-
       - name: Log in to Dockerhub
         uses: docker/login-action@v3
         with:
@@ -91,7 +74,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build testing Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ matrix.image_type }}/Dockerfile
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            MAUTIC_VERSION=${{ inputs.mautic_version }}
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: 'mautic/mautic:${{ inputs.mautic_version }}-${{ matrix.image_type }}'
+          format: 'sarif'
+          ignore-unfixed: true # Won't flag on unpatchable CVEs
+          output: 'trivy-results.sarif'
+          #trivyignores: .trivyignore
+      
+      - name: Upload Trivy SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Build and Push Docker image
         uses: docker/build-push-action@v5
         with:
           file: ${{ matrix.image_type }}/Dockerfile

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -91,13 +91,13 @@ jobs:
           image-ref: 'mautic/mautic:${{ inputs.mautic_version }}-${{ matrix.image_type }}'
           format: 'sarif'
           ignore-unfixed: true # Won't flag on unpatchable CVEs
-          output: 'trivy-results.sarif'
+          output: 'trivy-results-${{ matrix.image_type }}.sarif'
           #trivyignores: .trivyignore
       
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: 'trivy-results-${{ matrix.image_type }}.sarif'
 
       - name: Build and Push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -1,4 +1,8 @@
 name: Build and publish a Docker image
+permissions:
+  contents: read
+  security-events: write
+
 
 on:
   workflow_dispatch:
@@ -59,6 +63,20 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: 'mautic/mautic:${{ inputs.mautic_version }}-${{ matrix.image_type }}'
+          format: 'sarif'
+          ignore-unfixed: true # Won't flag on unpatchable CVEs
+          output: 'trivy-results.sarif'
+          #trivyignores: .trivyignore
+
+      - name: Upload Trivy SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
 
       - name: Log in to Dockerhub
         uses: docker/login-action@v3


### PR DESCRIPTION
This PR adds Trivy to the build and publish pipeline, sending results to the Security section of this repo.