### PR TITLE
Redesign pipeline for trivy

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -58,7 +58,7 @@ jobs:
 
   sast:
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs: test-build
     strategy:
       matrix:
         image_type: [apache, fpm]


### PR DESCRIPTION
This PR makes trivy run in parallel to the actual Docker build, aiming to solve the blocking problems noticed yesterday