### PR TITLE
Fix tmp being owned by root

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -132,8 +132,8 @@ COPY ./common/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Install composer
 COPY --from=builder /usr/bin/composer /usr/bin/composer
 
-# Set correct ownership for Mautic cache
-RUN chown -R www-data:www-data /var/www/html/var/cache/
+# Set correct ownership for Mautic var folder
+RUN chown -R www-data:www-data /var/www/html/var/
 
 # Define Mautic volumes to persist data
 VOLUME /var/www/html/config


### PR DESCRIPTION
Set ownership of whole `/var/www/html/var/` folder to `www-data`