### PR TITLE
Allow users to select specific build

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -116,6 +116,7 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{version}},value=${{ inputs.mautic_version }}
+            type=semver,pattern={{version}}-{{date 'YYYYMMDD'}},value=${{ inputs.mautic_version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.mautic_version }},enable=${{ inputs.overwrite_latest_minor }}
             type=semver,pattern={{major}},value=${{ inputs.mautic_version }},enable=${{ inputs.overwrite_latest_major }}
             type=raw,value=latest,enable=${{ inputs.tag_as_latest && matrix.image_type == 'apache' }},suffix=

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Some examples:
 * `5.0-fpm`: latest version in the 5.0 minor release in the `fpm` variant 
 * `5.0.3-apache`: specific point release of the `apache` variant
 
+It's also possible to target a specific build for a patch:
+
+* `<major.minor.patch>-<YYYYMMDD>-<variant>`
+
 ## Variants
 
 The Docker images exist in 2 variants:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Some examples:
 * `5.0-fpm`: latest version in the 5.0 minor release in the `fpm` variant 
 * `5.0.3-apache`: specific point release of the `apache` variant
 
-It's also possible to target a specific build for a patch:
+It's also possible to target a specific build for a given patch:
 
 * `<major.minor.patch>-<YYYYMMDD>-<variant>`
 


### PR DESCRIPTION
This PR introduces a `date` tag to Docker images, [inspired by the official Debian base image](https://hub.docker.com/_/debian).

Currently, images are overwritten each time a new build is pushed. As a result, if a broken build is uploaded to Docker Hub, users are unable to roll back to a previous functional build under the same version unless they have the older image saved locally. This feature was suggested by a user via Slack after a recent incident where a faulty build was pushed to Docker Hub.