### PR TITLE
Add SBOM

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -92,6 +92,36 @@ jobs:
         with:
           sarif_file: 'trivy-results-${{ matrix.image_type }}.sarif'
 
+  sbom:
+    runs-on: ubuntu-latest
+    needs: test-build
+    strategy:
+      matrix:
+        image_type: [apache, fpm]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: mautic-${{ matrix.image_type }}
+
+      - name: Load Docker image
+        run: docker load -i image.tar
+
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          scan-type: 'image'
+          image-ref: 'mautic-${{ matrix.image_type }}'
+          format: 'github'
+          output: 'dependency-results.sbom.json'
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+
   build-and-push-image:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -79,7 +79,7 @@ jobs:
         run: docker load -i image.tar
 
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           image-ref: 'mautic-${{ matrix.image_type }}'
           format: 'sarif'
@@ -114,7 +114,7 @@ jobs:
         run: docker load -i image.tar
 
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           scan-type: 'image'
           image-ref: 'mautic-${{ matrix.image_type }}'

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -62,7 +62,7 @@ jobs:
         run: docker load -i image.tar
 
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           image-ref: 'mautic-${{ matrix.image_type }}'
           format: 'table'


### PR DESCRIPTION
This PR adds a SBOM integrated to Github's dependency graph, using Trivy.

It also bumps Trivy to 0.31.0