### PR TITLE
Fix example to not induce errors

### DIFF
--- a/examples/basic/docker-compose.yml
+++ b/examples/basic/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     links:
       - db:mysql
     ports:
-      - 1111:80
+      - 8080:80
     volumes: *mautic-volumes
 
     environment:


### PR DESCRIPTION
This PR does a small fix on the port of the basic example, switching it from 1111 to 8080, for standardization.

This suggestion was raised through the #docker slack channel.