### PR TITLE
fix: Running Migrations On Clean Installs

### DIFF
--- a/common/entrypoint_mautic_web.sh
+++ b/common/entrypoint_mautic_web.sh
@@ -11,7 +11,7 @@ if [ "$DOCKER_MAUTIC_LOAD_TEST_DATA" = "true" ]; then
 fi
 
 # run migrations
-if php -r "include('${MAUTIC_VOLUME_CONFIG}/local.php'); exit(isset(\$parameters['site_url']) ? 0 : 1);"; then
+if php -r "include('${MAUTIC_VOLUME_CONFIG}/local.php'); exit(!empty(\$parameters['db_driver']) && !empty(\$parameters['site_url']) ? 0 : 1);"; then
   log "[${DOCKER_MAUTIC_ROLE}]: Mautic is already installed, running migrations..."
   su -s /bin/bash $MAUTIC_WWW_USER -c "php $MAUTIC_CONSOLE doctrine:migrations:migrate -n"
 else

--- a/common/entrypoint_mautic_web.sh
+++ b/common/entrypoint_mautic_web.sh
@@ -13,7 +13,7 @@ fi
 # run migrations
 if php -r "include('${MAUTIC_VOLUME_CONFIG}/local.php'); exit(isset(\$parameters['site_url']) ? 0 : 1);"; then
   log "[${DOCKER_MAUTIC_ROLE}]: Mautic is already installed, running migrations..."
-  su -s /bin/bash $MAUTIC_WWW_USER -c "php $MAUTIC_CONSOLE doctrine:migration:migrate -n"
+  su -s /bin/bash $MAUTIC_WWW_USER -c "php $MAUTIC_CONSOLE doctrine:migrations:migrate -n"
 else
   log "[${DOCKER_MAUTIC_ROLE}]: Mautic is not installed, skipping migrations."
 fi

--- a/common/entrypoint_mautic_web.sh
+++ b/common/entrypoint_mautic_web.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /startup/logger.sh
+
 # prepare mautic with test data
 if [ "$DOCKER_MAUTIC_LOAD_TEST_DATA" = "true" ]; then
   su -s /bin/bash $MAUTIC_WWW_USER -c "php $MAUTIC_CONSOLE doctrine:migrations:sync-metadata-storage"
@@ -9,7 +11,12 @@ if [ "$DOCKER_MAUTIC_LOAD_TEST_DATA" = "true" ]; then
 fi
 
 # run migrations
-su -s /bin/bash $MAUTIC_WWW_USER -c "php $MAUTIC_CONSOLE doctrine:migration:migrate -n"
+if php -r "include('${MAUTIC_VOLUME_CONFIG}/local.php'); exit(isset(\$parameters['site_url']) ? 0 : 1);"; then
+  log "[${DOCKER_MAUTIC_ROLE}]: Mautic is already installed, running migrations..."
+  su -s /bin/bash $MAUTIC_WWW_USER -c "php $MAUTIC_CONSOLE doctrine:migration:migrate -n"
+else
+  log "[${DOCKER_MAUTIC_ROLE}]: Mautic is not installed, skipping migrations."
+fi
 
 # execute the provided entrypoint
 "$@"

--- a/common/startup/wait_for_mautic_install.sh
+++ b/common/startup/wait_for_mautic_install.sh
@@ -4,7 +4,7 @@ source /startup/logger.sh
 
 function wait_for_mautic_install {
   local COUNTER=0
-  until php -r "include('${MAUTIC_VOLUME_CONFIG}/local.php'); exit(isset(\$parameters['site_url']) ? 0 : 1);"; do
+  until php -r "include('${MAUTIC_VOLUME_CONFIG}/local.php'); exit(!empty(\$parameters['db_driver']) && !empty(\$parameters['site_url']) ? 0 : 1);"; do
     log_debug "[${DOCKER_MAUTIC_ROLE}]: Waiting for Mautic to be installed, current attempt: ${COUNTER}."
     # only show message every 30 seconds (or DEBUG is enabled)
     if (( COUNTER % 6 == 0 )); then


### PR DESCRIPTION
This PR fixes #437, which was a bug introduced on #434, when trying to improve the upgrading process of the image.

Now migrations should only be ran when the container detects that Mautic is already installed, meaning, when local.php contains `parameters['site_url']`