### PR TITLE
fix: Unable to locate package libc-client-dev

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-apache AS builder
+FROM php:8.3-apache-bookworm AS builder
 
 # Copy everything from common for building
 COPY ./common/ /common/

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -63,7 +63,7 @@ RUN cd /opt && \
     rm -rf /opt/mautic/var/cache/js && \
     find /opt/mautic/node_modules -mindepth 1 -maxdepth 1 -not \( -name 'jquery' -or -name 'vimeo-froogaloop2' \) | xargs rm -rf
 
-FROM php:8.3-apache
+FROM php:8.3-apache-bookworm
 
 LABEL vendor="Mautic"
 LABEL maintainer="Mautic core team <>"

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -63,7 +63,7 @@ RUN cd /opt && \
     rm -rf /opt/mautic/var/cache/js && \
     find /opt/mautic/node_modules -mindepth 1 -maxdepth 1 -not \( -name 'jquery' -or -name 'vimeo-froogaloop2' \) | xargs rm -rf
 
-FROM php:8.3-fpm
+FROM php:8.3-fpm-bookworm
 
 LABEL vendor="Mautic"
 LABEL maintainer="Mautic core team <>"

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-fpm AS builder
+FROM php:8.3-fpm-bookworm AS builder
 
 # Copy everything from common for building
 COPY ./common/ /common/


### PR DESCRIPTION
**Error**
E: Unable to locate package libc-client-dev

**Cause**
php:8.X-apache and php:8.X-fpm are now based on debian 13 and libc-client-dev is not available on debian 13.

**Fix**
Explicitly choose bookworm (debian 12) which is the previous base for php:8.X-apache and php:8.X-fpm.