### PR TITLE
[BUG] Improve clarity on DB connection

### DIFF
--- a/common/startup/check_database_connection.sh
+++ b/common/startup/check_database_connection.sh
@@ -32,7 +32,7 @@ function check_database_connection {
   # we either maxed our connection attempts or we got a successful response
   log_debug "MySQL connection check response: ${IS_MYSQL_ALIVE}"
   if [[ "${IS_MYSQL_ALIVE}" == "mysqld is alive" ]]; then
-    log_debug "MySQL is alive and well."
+    log "MySQL is alive and well."
   fi
 }
 


### PR DESCRIPTION
This PR facilitates the diagnostic of DB connections with the container, making the message "MySQL is alive and well." appear directly on logs by default.

Read #448 for more details.