### PR TITLE
[BUG] Improved string matching with exit-code-based detection for db connection

### DIFF
--- a/common/startup/check_database_connection.sh
+++ b/common/startup/check_database_connection.sh
@@ -24,7 +24,6 @@ function check_database_connection {
   done
 
   # Max attempts reached
-  log_startup_error_header
   log_error "MySQL is not responding after ${MAX_FAILURE_COUNT} attempts. Exiting."
   log_error "Please ensure the MySQL server is running and accessible from this container."
   exit 1


### PR DESCRIPTION
Fixes issue: #448 

This PR fixes the MySQL connection retry logic in the Docker Mautic container startup script.
Currently, the startup script relies on string matching to detect whether MySQL is alive:

**Problem with String-Based Matching**

- Unreliable output: mysqladmin ping may print warnings, the script checks for exact string equality, any extra text (like the warning) causes the condition to never evaluate to true.
- Logical issue: Even if the database is up and reachable, the loop continues indefinitely, printing "MySQL is not ready yet" and hanging the container startup. (This is exact case what I was facing)

**Changes Made**

- Replaced string matching with exit-code-based detection using mysqladmin ping.
- Exit code 0 → MySQL is reachable.
- Exit code non-zero → retry.
- Added retry loop with configurable max attempts (MAX_FAILURE_COUNT) and logging.
- Avoids issues with warnings, extra messages, or output formatting changes.
- Ensures the container does not hang indefinitely if MySQL is temporarily unavailable.

**Why This is Necessary**

- Fixes container startup hangs when MySQL is not immediately available.
- Improves robustness and reliability of the Mautic Docker setup.
- Aligns with best practices for checking database availability in scripts.
