### PR TITLE
Fix: add missing env vars to rabbitmq service in example docker-compose

### DIFF
--- a/examples/rabbitmq-worker/docker-compose.yml
+++ b/examples/rabbitmq-worker/docker-compose.yml
@@ -28,6 +28,8 @@ services:
   rabbitmq:
     image: rabbitmq:3
     environment:
+      - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
+      - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
       - RABBITMQ_DEFAULT_VHOST=${RABBITMQ_DEFAULT_VHOST}
     volumes: 
       - rabbitmq-data:/var/lib/rabbitmq


### PR DESCRIPTION
Adds missing env vars to RabbitMQ example as discussed in issue #452 