### PR TITLE
fix: php ini or mautic values for cron

### DIFF
--- a/common/entrypoint_mautic_cron.sh
+++ b/common/entrypoint_mautic_cron.sh
@@ -21,7 +21,7 @@ mkfifo /tmp/stdout
 chmod 777 /tmp/stdout
 
 # ensure the PHP env vars are present during cronjobs
-declare -p | grep 'PHP_INI_VALUE_' > /tmp/cron.env
+declare -p | grep -E 'PHP_INI_VALUE_|MAUTIC' > /tmp/cron.env
 
 # run cron and print the output
 cron -f | tail -f /tmp/stdout


### PR DESCRIPTION
This fixes an issue where the cron env file is missing several values from the env that cause the cron jobs to fail to be able to function