### PR TITLE
Add missing gd Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,7 @@ RUN apt-get update \
     libpng16-16 \
     libwebp7 \
     libc-client2007e \
+    libxpm4 \
     libzip4 \
     mariadb-client \
     supervisor \

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     cron \
     git \
+    libavif15 \
     librabbitmq4 \
     libfreetype6 \
     libjpeg62-turbo \


### PR DESCRIPTION
This PR fixes an issue where GD fails to initialize due to a missing library. Related to #470 and #469.