### PR TITLE
Improve Docker build and make image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,16 @@ COPY --from=builder /common/templates/php.ini /usr/local/etc/php/php.ini
 
 COPY --from=builder --chown=www-data:www-data /opt/mautic /var/www/html
 
+# Verify web assets were built in the builder stage
+RUN for f in \
+        docroot/media/css/app.css \
+        docroot/media/css/libraries.css \
+        docroot/media/js/app.js \
+        docroot/media/js/libraries.js \
+        docroot/media/libraries/ckeditor/ckeditor.js; do \
+    test -s "/var/www/html/$f" || { echo "ERROR: Missing asset: $f"; exit 1; }; \
+    done
+
 # Copy all files needed for startup
 COPY --from=builder --chmod=755 /common/startup/ /startup/
 COPY --from=builder --chown=www-data:www-data --chmod=755 /common/templates/ /templates/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update \
     git \
     unzip \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y nodejs \
+    && apt-get install --no-install-recommends -y nodejs \
+    && rm -rf /var/lib/apt/lists/* \
     && npm install -g npm@latest
 
 # PHP extensions install script
@@ -42,7 +43,10 @@ ARG MAUTIC_VERSION=7.x-dev
 RUN cd /opt && \
     COMPOSER_ALLOW_SUPERUSER=1 COMPOSER_PROCESS_TIMEOUT=10000 composer create-project mautic/recommended-project:${MAUTIC_VERSION} mautic --no-interaction && \
     rm -rf /opt/mautic/var/cache/js && \
-    find /opt/mautic/node_modules -mindepth 1 -maxdepth 1 -not \( -name 'jquery' -or -name 'vimeo-froogaloop2' \) | xargs rm -rf
+    cd /opt/mautic && \
+    npm ci && \
+    php bin/console mautic:assets:generate && \
+    find node_modules -mindepth 1 -maxdepth 1 -not \( -name 'jquery' -or -name 'vimeo-froogaloop2' \) -exec rm -rf {} +
 
 FROM php:${BASE_TAG}
 
@@ -129,16 +133,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm /etc/cron.daily/*
 
-# Install Node.JS
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y nodejs && \
-    npm install -g npm@latest
-
-# Rebuild web assets
-RUN cd /var/www/html && \
-    npm install && \
-    php bin/console mautic:assets:generate && \
-    php bin/console cache:clear
+# Clear cache to ensure correct paths after copy from builder
+RUN cd /var/www/html && php bin/console cache:clear
 
 RUN if [ "$FLAVOUR" = "apache" ]; then \
         sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \


### PR DESCRIPTION
> [!NOTE]
> This PR assumes that Node.js is not needed at runtime in the final image.

## Summary

Move Node.js and web asset generation entirely into the builder stage so the final image no longer contains Node.js, npm, or node\_modules. This reduces the uncompressed image size by ~700 MB (~33%).

| Image | Uncompressed size |
|-------|------------------|
| Before (Node.js in final stage) | 2.17 GB |
| After (this PR) | 1.46 GB |

## Changes

**Builder stage**
- Install Node.js 22 from nodesource instead of Debian packages — fixes `ERR_REQUIRE_ESM` errors with Mautic 7's webpack config that made builds with `7.x-dev` fail entirely
- Run `npm ci` and `php bin/console mautic:assets:generate` in the builder before copying to the final image

**Final stage**
- Remove Node.js installation and `npm ci` (no longer needed)
- Replace the combined asset build + cache clear step with a standalone `php bin/console cache:clear` to regenerate Symfony cache paths after copy from builder
- Add `libavif15` and `libxpm4` to fix pre-existing GD extension warnings
- Add a build-time assertion that verifies key webpack assets (`app.css`, `app.js`, `libraries.css`, `libraries.js`, `ckeditor.js`) exist and are non-empty — build fails immediately with a clear error if asset generation broke

**Other**
- Use `--no-install-recommends` and clean apt lists in the same layer for the `nodejs` install in builder
- Use `find -exec rm -rf {} +` instead of `| xargs rm -rf` for safer node\_modules pruning